### PR TITLE
WP-465-group-mobile-not-ringing

### DIFF
--- a/xivo_dao/resources/func_key/hint_dao.py
+++ b/xivo_dao/resources/func_key/hint_dao.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2014-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2014-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from sqlalchemy import (
@@ -99,7 +99,7 @@ def user_shared_hints(session):
     query = session.query(UserFeatures).options(joinedload('user_lines').joinedload('line'))
     hints = []
     for user in query.all():
-        ifaces = ['Custom:{}'.format(user.uuid)]
+        ifaces = ['Custom:{}-mobile'.format(user.uuid)]
         for line in user.lines:
             if line.endpoint_custom_id:
                 ifaces.append(line.name)

--- a/xivo_dao/resources/func_key/tests/test_hint_dao.py
+++ b/xivo_dao/resources/func_key/tests/test_hint_dao.py
@@ -555,7 +555,7 @@ class TestUserSharedHints(TestHints):
 
         assert_that(
             results[0].argument,
-            equal_to('Custom:{}&pjsip/{}&{}&sccp/{}'.format(user.uuid, line_1.name, line_2.name, line_3.name)),
+            equal_to('Custom:{}-mobile&pjsip/{}&{}&sccp/{}'.format(user.uuid, line_1.name, line_2.name, line_3.name)),
         )
 
     def test_no_line(self):
@@ -563,4 +563,4 @@ class TestUserSharedHints(TestHints):
 
         results = hint_dao.user_shared_hints()
 
-        assert_that(results[0].argument, equal_to('Custom:{}'.format(user.uuid)))
+        assert_that(results[0].argument, equal_to('Custom:{}-mobile'.format(user.uuid)))


### PR DESCRIPTION
this new hint will be used to control if a user has a mobile session or not