### PR TITLE
[ITEM-205] Remove call listening / *34

### DIFF
--- a/xivo_dao/resources/extension/database.py
+++ b/xivo_dao/resources/extension/database.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
@@ -33,7 +33,6 @@ class ServiceExtensionConverter:
         "vmuserpurge",
         "phonestatus",
         "recsnd",
-        "calllistening",
         "directoryaccess",
         "fwdundoall",
         "pickup",

--- a/xivo_dao/resources/feature_extension/database.py
+++ b/xivo_dao/resources/feature_extension/database.py
@@ -1,4 +1,4 @@
-# Copyright 2023-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2023-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
@@ -33,7 +33,6 @@ class ServiceFeatureExtensionConverter:
         "vmuserpurge",
         "phonestatus",
         "recsnd",
-        "calllistening",
         "directoryaccess",
         "fwdundoall",
         "pickup",

--- a/xivo_dao/resources/feature_extension/tests/test_dao.py
+++ b/xivo_dao/resources/feature_extension/tests/test_dao.py
@@ -1,4 +1,4 @@
-# Copyright 2023-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2023-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from uuid import uuid4
@@ -282,7 +282,6 @@ class TestFindAllServiceExtensions(DAOTestCase):
         ("*92", "vmuserpurge"),
         ("*10", "phonestatus"),
         ("*9", "recsnd"),
-        ("*34", "calllistening"),
         ("*36", "directoryaccess"),
         ("*20", "fwdundoall"),
         ("_*8.", "pickup"),
@@ -297,7 +296,6 @@ class TestFindAllServiceExtensions(DAOTestCase):
         ("*92", "vmuserpurge"),
         ("*10", "phonestatus"),
         ("*9", "recsnd"),
-        ("*34", "calllistening"),
         ("*36", "directoryaccess"),
         ("*20", "fwdundoall"),
         ("*8", "pickup"),


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk, as this only removes one service identifier from the allowed service-extension lists and updates the corresponding test expectations; impact is limited to setups that still rely on `calllistening`/`*34` being returned or accepted.
> 
> **Overview**
> Removes support for the `calllistening` service extension (`*34`) from both `ServiceExtensionConverter.SERVICES` and `ServiceFeatureExtensionConverter.SERVICES`, so it is no longer considered a valid service/feature extension.
> 
> Updates `feature_extension` DAO tests to stop seeding and asserting `calllistening` entries, and refreshes copyright headers to 2026.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit acb4e57db739ad7a14b53a81bf5caf3659b1cd8f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->