### PR TITLE
[TASK-254] agent_dao: fix types

### DIFF
--- a/xivo_dao/agent_dao.py
+++ b/xivo_dao/agent_dao.py
@@ -15,14 +15,6 @@ from xivo_dao.alchemy.userfeatures import UserFeatures
 from xivo_dao.helpers.db_manager import daosession
 
 
-class _Agent(NamedTuple):
-    id: int
-    tenant_uuid: str
-    number: str
-    queues: list[QueueFeatures]
-    user_ids: list[int]
-
-
 class _Queue(NamedTuple):
     id: int
     tenant_uuid: str
@@ -30,22 +22,30 @@ class _Queue(NamedTuple):
     penalty: int
 
 
+class _Agent(NamedTuple):
+    id: int
+    tenant_uuid: str
+    number: str
+    queues: list[_Queue]
+    user_ids: list[int]
+
+
 @daosession
-def agent_with_id(session, agent_id, tenant_uuids=None):
+def agent_with_id(session, agent_id, tenant_uuids=None) -> _Agent:
     agent = _get_agent(session, AgentFeatures.id == int(agent_id), tenant_uuids)
     _add_queues_to_agent(session, agent)
     return agent
 
 
 @daosession
-def agent_with_number(session, agent_number, tenant_uuids=None):
+def agent_with_number(session, agent_number, tenant_uuids=None) -> _Agent:
     agent = _get_agent(session, AgentFeatures.number == agent_number, tenant_uuids)
     _add_queues_to_agent(session, agent)
     return agent
 
 
 @daosession
-def agent_with_user_uuid(session, user_uuid, tenant_uuids=None):
+def agent_with_user_uuid(session, user_uuid, tenant_uuids=None) -> _Agent:
     query = (
         session.query(AgentFeatures)
         .join(UserFeatures, AgentFeatures.id == UserFeatures.agentid)
@@ -68,7 +68,7 @@ def agent_with_user_uuid(session, user_uuid, tenant_uuids=None):
     return agent
 
 
-def _get_agent(session, whereclause, tenant_uuids=None):
+def _get_agent(session, whereclause, tenant_uuids=None) -> _Agent:
     query = session.query(AgentFeatures).filter(whereclause)
     if tenant_uuids is not None:
         query = query.filter(AgentFeatures.tenant_uuid.in_(tenant_uuids))
@@ -80,7 +80,7 @@ def _get_agent(session, whereclause, tenant_uuids=None):
     )
 
 
-def _add_queues_to_agent(session, agent):
+def _add_queues_to_agent(session, agent) -> None:
     query = (
         select(
             QueueFeatures.id,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to type annotations and NamedTuple field definitions in `agent_dao`, with no intended behavior change beyond improving static typing.
> 
> **Overview**
> Fixes typing in `agent_dao` by correcting the `_Agent`/`_Queue` `NamedTuple` definitions (including `_Agent.queues` now being `list[_Queue]`) and adding explicit return type annotations to the agent lookup helpers (`agent_with_id`, `agent_with_number`, `agent_with_user_uuid`, `_get_agent`, `_add_queues_to_agent`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0894b299e6e065de633a41834ba2518984cd94f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->