### PR TITLE
feat(mobile-pstn-fallback): add mobile_fallback_enabled to User

### DIFF
--- a/xivo_dao/alchemy/__init__.py
+++ b/xivo_dao/alchemy/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2014-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 # explicitly import modules that are referenced in relationship to prevent
@@ -10,6 +10,9 @@ from xivo_dao.alchemy.application import Application
 from xivo_dao.alchemy.application_dest_node import ApplicationDestNode
 from xivo_dao.alchemy.asterisk_file_section import AsteriskFileSection
 from xivo_dao.alchemy.asterisk_file_variable import AsteriskFileVariable
+from xivo_dao.alchemy.blocklist import Blocklist
+from xivo_dao.alchemy.blocklist_number import BlocklistNumber
+from xivo_dao.alchemy.blocklist_user import BlocklistUser
 from xivo_dao.alchemy.callfilter import Callfilter
 from xivo_dao.alchemy.callfiltermember import Callfiltermember
 from xivo_dao.alchemy.conference import Conference
@@ -76,6 +79,9 @@ __all__ = [
     'ApplicationDestNode',
     'AsteriskFileSection',
     'AsteriskFileVariable',
+    'Blocklist',
+    'BlocklistNumber',
+    'BlocklistUser',
     'Callfilter',
     'Callfiltermember',
     'Conference',

--- a/xivo_dao/alchemy/userfeatures.py
+++ b/xivo_dao/alchemy/userfeatures.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import datetime
@@ -130,6 +130,7 @@ class UserFeatures(Base):
     musiconhold = Column(String(128), nullable=False, server_default='')
     outcallerid = Column(String(80), nullable=False, server_default='')
     mobilephonenumber = Column(String(128), nullable=False, server_default='')
+    mobile_fallback_enabled = Column(Boolean, nullable=False, server_default='false')
     bsfilter = Column(enum.generic_bsfilter, nullable=False, server_default='no')
     preprocess_subroutine = Column(String(79))
     timezone = Column(String(128))

--- a/xivo_dao/helpers/errors.py
+++ b/xivo_dao/helpers/errors.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from xivo_dao.helpers.exception import InputError, NotFoundError, ResourceError
@@ -94,6 +94,10 @@ resource_not_associated = FormattedError(ResourceError, "{} is not associated wi
 missing_association = FormattedError(ResourceError, "{} must be associated with a {}")
 forward_destination_null = FormattedError(
     ResourceError, "Forward must be disabled to remove destination"
+)
+mobile_fallback_number_null = FormattedError(
+    ResourceError,
+    "PSTN fallback must be disabled when mobile phone number is not set",
 )
 unhandled_context_type = FormattedError(
     ResourceError, "ContextType '{}' cannot be associated"

--- a/xivo_dao/resources/user/tests/test_dao.py
+++ b/xivo_dao/resources/user/tests/test_dao.py
@@ -874,6 +874,7 @@ class TestCreate(TestUser):
                 description=none(),
                 outgoing_caller_id=none(),
                 mobile_phone_number=none(),
+                mobile_fallback_enabled=False,
                 call_permission_password=none(),
                 enabled=True,
                 caller_id='"Jôhn"',
@@ -947,6 +948,7 @@ class TestCreate(TestUser):
             caller_id='"fîrstname lâstname" <1000>',
             outgoing_caller_id='ôutgoing_caller_id',
             mobile_phone_number='1234567890',
+            mobile_fallback_enabled=True,
             call_permission_password='1234',
             enabled=False,
             username='username',
@@ -994,6 +996,7 @@ class TestCreate(TestUser):
                 caller_id='"fîrstname lâstname" <1000>',
                 outgoing_caller_id='ôutgoing_caller_id',
                 mobile_phone_number='1234567890',
+                mobile_fallback_enabled=True,
                 call_permission_password='1234',
                 enabled=False,
                 username='username',
@@ -1094,6 +1097,7 @@ class TestEdit(TestUser):
         user.caller_id = '"John Sparrow"'
         user.outgoing_caller_id = 'outgoing_caller_id'
         user.mobile_phone_number = '1234567890'
+        user.mobile_fallback_enabled = True
         user.call_permission_password = '1234'
         user.enabled = False
         user.username = 'username'
@@ -1137,6 +1141,7 @@ class TestEdit(TestUser):
                 caller_id='"John Sparrow"',
                 outgoing_caller_id='outgoing_caller_id',
                 mobile_phone_number='1234567890',
+                mobile_fallback_enabled=True,
                 call_permission_password='1234',
                 enabled=False,
                 username='username',


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new persisted boolean field on `userfeatures`, which requires a DB schema migration/compatibility and can affect any code reading/writing user records. Test updates reduce risk, but downstream services must handle the new column and default behavior correctly.
> 
> **Overview**
> Adds a new boolean field, `mobile_fallback_enabled`, to the `UserFeatures` (`userfeatures`) SQLAlchemy model with a default of `false`, enabling persistence of a per-user PSTN mobile fallback toggle.
> 
> Introduces a new formatted `ResourceError` (`mobile_fallback_number_null`) for cases where PSTN fallback must be disabled when no mobile number is set, and updates user DAO tests to assert the new field on create/edit flows. Also updates `alchemy/__init__.py` to export `Blocklist*` models.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b29976027b619d534d9dddc94689a554dc57a15b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->