### PR TITLE
[ITEM-295] Agent stats per queues

### DIFF
--- a/xivo_dao/alchemy/stat_agent_periodic.py
+++ b/xivo_dao/alchemy/stat_agent_periodic.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from sqlalchemy.dialects.postgresql import INTERVAL
@@ -7,6 +7,7 @@ from sqlalchemy.schema import Column, ForeignKey, Index
 from sqlalchemy.types import DateTime, Integer
 
 from xivo_dao.alchemy.stat_agent import StatAgent
+from xivo_dao.alchemy.stat_queue import StatQueue
 from xivo_dao.helpers.db_manager import Base
 
 
@@ -14,6 +15,7 @@ class StatAgentPeriodic(Base):
     __tablename__ = 'stat_agent_periodic'
     __table_args__ = (
         Index('stat_agent_periodic__idx__stat_agent_id', 'stat_agent_id'),
+        Index('stat_agent_periodic__idx__stat_queue_id', 'stat_queue_id'),
         Index('stat_agent_periodic__idx__time', 'time'),
     )
 
@@ -23,5 +25,7 @@ class StatAgentPeriodic(Base):
     pause_time = Column(INTERVAL, nullable=False, server_default='0')
     wrapup_time = Column(INTERVAL, nullable=False, server_default='0')
     stat_agent_id = Column(Integer, ForeignKey("stat_agent.id"))
+    stat_queue_id = Column(Integer, ForeignKey("stat_queue.id"), nullable=True)
 
     stat_agent = relationship(StatAgent, foreign_keys=stat_agent_id)
+    stat_queue = relationship(StatQueue, foreign_keys=stat_queue_id)

--- a/xivo_dao/queue_log_dao.py
+++ b/xivo_dao/queue_log_dao.py
@@ -58,7 +58,9 @@ AND
             row.start,
             row.end,
         )
-        keys = ((agent_id, None), (agent_id, queue_name))
+        # a set: when queue_name is NULL both keys collapse to (agent_id, None),
+        # which must only be accumulated once
+        keys = {(agent_id, None), (agent_id, queue_name)}
 
         starting_period = _find_including_period(periods, wstart)
         ending_period = _find_including_period(periods, wend)

--- a/xivo_dao/queue_log_dao.py
+++ b/xivo_dao/queue_log_dao.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -23,6 +23,7 @@ def get_wrapup_times(session, start, end, interval):
 SELECT
     queue_log.time AS start,
     (queue_log.time + (queue_log.data1 || ' seconds')::INTERVAL) AS end,
+    queue_log.queuename AS queue_name,
     stat_agent.id AS agent_id
 FROM
     queue_log
@@ -40,7 +41,10 @@ AND
 
     rows = (
         session.query(
-            literal_column('start'), literal_column('end'), literal_column('agent_id')
+            literal_column('start'),
+            literal_column('end'),
+            literal_column('queue_name'),
+            literal_column('agent_id'),
         )
         .from_statement(text(wrapup_times_query))
         .params(start=formatted_start, end=formatted_end)
@@ -48,7 +52,13 @@ AND
 
     results = {}
     for row in rows.all():
-        agent_id, wstart, wend = row.agent_id, row.start, row.end
+        agent_id, queue_name, wstart, wend = (
+            row.agent_id,
+            row.queue_name,
+            row.start,
+            row.end,
+        )
+        keys = ((agent_id, None), (agent_id, queue_name))
 
         starting_period = _find_including_period(periods, wstart)
         ending_period = _find_including_period(periods, wend)
@@ -62,19 +72,21 @@ AND
             range_end = starting_period + interval
             wend_in_start = wend if wend < range_end else range_end
             time_in_period = wend_in_start - wstart
-            if agent_id not in results[starting_period]:
-                results[starting_period][agent_id] = {
-                    'wrapup_time': timedelta(seconds=0)
-                }
-            results[starting_period][agent_id]['wrapup_time'] += time_in_period
+            for key in keys:
+                if key not in results[starting_period]:
+                    results[starting_period][key] = {
+                        'wrapup_time': timedelta(seconds=0)
+                    }
+                results[starting_period][key]['wrapup_time'] += time_in_period
 
         if ending_period == starting_period:
             continue
 
         time_in_period = wend - ending_period
-        if agent_id not in results[ending_period]:
-            results[ending_period][agent_id] = {'wrapup_time': timedelta(seconds=0)}
-        results[ending_period][agent_id]['wrapup_time'] += time_in_period
+        for key in keys:
+            if key not in results[ending_period]:
+                results[ending_period][key] = {'wrapup_time': timedelta(seconds=0)}
+            results[ending_period][key]['wrapup_time'] += time_in_period
 
     return results
 

--- a/xivo_dao/stat_agent_periodic_dao.py
+++ b/xivo_dao/stat_agent_periodic_dao.py
@@ -1,10 +1,10 @@
-# Copyright 2013-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from xivo_dao.alchemy.stat_agent_periodic import StatAgentPeriodic
 
 
-def insert_stats(session, period_stats, period_start):
+def insert_stats(session, period_stats, period_start, stat_queue_id=None):
     for agent_id, times in period_stats.items():
         entry = StatAgentPeriodic(
             time=period_start,
@@ -12,6 +12,7 @@ def insert_stats(session, period_stats, period_start):
             pause_time=times['pause_time'] if 'pause_time' in times else '00:00:00',
             wrapup_time=times['wrapup_time'] if 'wrapup_time' in times else '00:00:00',
             stat_agent_id=agent_id,
+            stat_queue_id=stat_queue_id,
         )
 
         session.add(entry)

--- a/xivo_dao/stat_agent_periodic_dao.py
+++ b/xivo_dao/stat_agent_periodic_dao.py
@@ -4,14 +4,14 @@
 from xivo_dao.alchemy.stat_agent_periodic import StatAgentPeriodic
 
 
-def insert_stats(session, period_stats, period_start, stat_queue_id=None):
-    for agent_id, times in period_stats.items():
+def insert_stats(session, period_stats, period_start):
+    for (stat_agent_id, stat_queue_id), times in period_stats.items():
         entry = StatAgentPeriodic(
             time=period_start,
             login_time=times['login_time'] if 'login_time' in times else '00:00:00',
             pause_time=times['pause_time'] if 'pause_time' in times else '00:00:00',
             wrapup_time=times['wrapup_time'] if 'wrapup_time' in times else '00:00:00',
-            stat_agent_id=agent_id,
+            stat_agent_id=stat_agent_id,
             stat_queue_id=stat_queue_id,
         )
 

--- a/xivo_dao/stat_dao.py
+++ b/xivo_dao/stat_dao.py
@@ -233,7 +233,6 @@ def _get_per_queue_pause_intervals(session, start, end):
         end,
         open_event='PAUSE',
         close_event='UNPAUSE',
-        agent_join=_AGENT_NAME_JOIN,
     )
 
 
@@ -260,14 +259,6 @@ def get_login_intervals_in_range(session, start, end):
     return output
 
 
-_AGENT_NAME_JOIN = 'stat_agent.name = queue_log.agent'
-_AGENT_NAME_OR_INTERFACE_JOIN = '''\
-stat_agent.name = queue_log.agent
-        OR stat_agent.agent_id = CAST(
-            substring(queue_log.agent FROM '^Local/id-([0-9]+)@agentcallback') AS INTEGER
-        )'''
-
-
 def _get_agent_queue_membership_intervals(session, start, end):
     return _get_open_close_intervals_by_queue(
         session,
@@ -275,14 +266,11 @@ def _get_agent_queue_membership_intervals(session, start, end):
         end,
         open_event='ADDMEMBER',
         close_event='REMOVEMEMBER',
-        agent_join=_AGENT_NAME_OR_INTERFACE_JOIN,
     )
 
 
-def _get_open_close_intervals_by_queue(
-    session, start, end, open_event, close_event, agent_join
-):
-    open_at_start_query = f'''\
+def _get_open_close_intervals_by_queue(session, start, end, open_event, close_event):
+    open_at_start_query = '''\
 SELECT
     agent_id,
     queue_name,
@@ -296,14 +284,17 @@ FROM (
         queue_log.event AS event_type
     FROM queue_log
     JOIN stat_agent ON (
-        {agent_join}
+        stat_agent.name = queue_log.agent
+        OR stat_agent.agent_id = CAST(
+            substring(queue_log.agent FROM '^Local/id-([0-9]+)@agentcallback') AS INTEGER
+        )
     )
     WHERE queue_log.event IN (:open_event, :close_event)
     AND queue_log.time < :start
 ) past_events
 GROUP BY agent_id, queue_name
 '''
-    in_range_query = f'''\
+    in_range_query = '''\
 SELECT
     stat_agent.id AS agent_id,
     queue_log.queuename AS queue_name,
@@ -311,7 +302,10 @@ SELECT
     queue_log.event AS event_type
 FROM queue_log
 JOIN stat_agent ON (
-    {agent_join}
+    stat_agent.name = queue_log.agent
+    OR stat_agent.agent_id = CAST(
+        substring(queue_log.agent FROM '^Local/id-([0-9]+)@agentcallback') AS INTEGER
+    )
 )
 WHERE queue_log.event IN (:open_event, :close_event)
 AND queue_log.time >= :start

--- a/xivo_dao/stat_dao.py
+++ b/xivo_dao/stat_dao.py
@@ -304,7 +304,12 @@ FROM (
         queue_log.time AS event_time,
         queue_log.event AS event_type
     FROM queue_log
-    JOIN stat_agent ON stat_agent.name = queue_log.agent
+    JOIN stat_agent ON (
+        stat_agent.name = queue_log.agent
+        OR stat_agent.agent_id = CAST(
+            substring(queue_log.agent FROM '^Local/id-([0-9]+)@agentcallback') AS INTEGER
+        )
+    )
     WHERE queue_log.event IN ('ADDMEMBER', 'REMOVEMEMBER')
     AND queue_log.time < :end
 ) membership_events

--- a/xivo_dao/stat_dao.py
+++ b/xivo_dao/stat_dao.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from sqlalchemy.sql import literal_column, text
@@ -193,11 +193,11 @@ SELECT stat_agent.id AS agent,
     results = {}
 
     for row in rows.all():
-        agent_id = row.agent
-        if agent_id not in results:
-            results[agent_id] = []
+        key = (row.agent, None)
+        if key not in results:
+            results[key] = []
 
-        results[agent_id].append((row.pauseall, row.unpauseall))
+        results[key].append((row.pauseall, row.unpauseall))
 
     return results
 
@@ -211,13 +211,58 @@ def get_login_intervals_in_range(session, start, end):
         ongoing_logins,
     )
 
-    unique_result = {}
-
+    output = {}
     for agent, logins in results.items():
         logins = _pick_longest_with_same_end(logins)
-        unique_result[agent] = sorted(list(set(logins)))
+        output[(agent, None)] = sorted(list(set(logins)))
 
-    return unique_result
+    membership = _get_agent_queue_membership_intervals(session, start, end)
+    for key, intervals in membership.items():
+        output[key] = intervals
+
+    return output
+
+
+def _get_agent_queue_membership_intervals(session, start, end):
+    query = '''\
+SELECT
+    agent_id,
+    queue_name,
+    event_time,
+    event_type,
+    LEAD(event_time) OVER w AS next_event_time
+FROM (
+    SELECT
+        stat_agent.id AS agent_id,
+        queue_log.queuename AS queue_name,
+        queue_log.time AS event_time,
+        queue_log.event AS event_type
+    FROM queue_log
+    JOIN stat_agent ON stat_agent.name = queue_log.agent
+    WHERE queue_log.event IN ('ADDMEMBER', 'REMOVEMEMBER')
+    AND queue_log.time < :end
+) membership_events
+WINDOW w AS (PARTITION BY agent_id, queue_name ORDER BY event_time)
+ORDER BY agent_id, queue_name, event_time
+'''
+    formatted_start = start.strftime(_STR_TIME_FMT)
+    formatted_end = end.strftime(_STR_TIME_FMT)
+    rows = session.execute(
+        text(query),
+        {'start': formatted_start, 'end': formatted_end},
+    )
+
+    intervals = {}
+    for row in rows:
+        if row.event_type != 'ADDMEMBER':
+            continue
+        interval_start = max(row.event_time, start)
+        interval_end = min(row.next_event_time or end, end)
+        if interval_end <= interval_start:
+            continue
+        key = (row.agent_id, row.queue_name)
+        intervals.setdefault(key, []).append((interval_start, interval_end))
+    return intervals
 
 
 def _merge_agent_statistics(*args):

--- a/xivo_dao/stat_dao.py
+++ b/xivo_dao/stat_dao.py
@@ -227,45 +227,14 @@ SELECT stat_agent.id AS agent,
 
 
 def _get_per_queue_pause_intervals(session, start, end):
-    query = '''\
-SELECT
-    agent_id,
-    queue_name,
-    event_time,
-    event_type,
-    LEAD(event_time) OVER w AS next_event_time
-FROM (
-    SELECT
-        stat_agent.id AS agent_id,
-        queue_log.queuename AS queue_name,
-        queue_log.time AS event_time,
-        queue_log.event AS event_type
-    FROM queue_log
-    JOIN stat_agent ON stat_agent.name = queue_log.agent
-    WHERE queue_log.event IN ('PAUSE', 'UNPAUSE')
-    AND queue_log.time < :end
-) pause_events
-WINDOW w AS (PARTITION BY agent_id, queue_name ORDER BY event_time)
-ORDER BY agent_id, queue_name, event_time
-'''
-    formatted_start = start.strftime(_STR_TIME_FMT)
-    formatted_end = end.strftime(_STR_TIME_FMT)
-    rows = session.execute(
-        text(query),
-        {'start': formatted_start, 'end': formatted_end},
+    return _get_open_close_intervals_by_queue(
+        session,
+        start,
+        end,
+        open_event='PAUSE',
+        close_event='UNPAUSE',
+        agent_join=_AGENT_NAME_JOIN,
     )
-
-    intervals = {}
-    for row in rows:
-        if row.event_type != 'PAUSE':
-            continue
-        interval_start = max(row.event_time, start)
-        interval_end = min(row.next_event_time or end, end)
-        if interval_end <= interval_start:
-            continue
-        key = (row.agent_id, row.queue_name)
-        intervals.setdefault(key, []).append((interval_start, interval_end))
-    return intervals
 
 
 def get_login_intervals_in_range(session, start, end):
@@ -283,20 +252,42 @@ def get_login_intervals_in_range(session, start, end):
         output[(agent, None)] = sorted(list(set(logins)))
 
     membership = _get_agent_queue_membership_intervals(session, start, end)
-    for key, intervals in membership.items():
-        output[key] = intervals
+    for (agent_id, queue_name), intervals in membership.items():
+        logged_in = _intersect_intervals(output.get((agent_id, None), []), intervals)
+        if logged_in:
+            output[(agent_id, queue_name)] = logged_in
 
     return output
 
 
+_AGENT_NAME_JOIN = 'stat_agent.name = queue_log.agent'
+_AGENT_NAME_OR_INTERFACE_JOIN = '''\
+stat_agent.name = queue_log.agent
+        OR stat_agent.agent_id = CAST(
+            substring(queue_log.agent FROM '^Local/id-([0-9]+)@agentcallback') AS INTEGER
+        )'''
+
+
 def _get_agent_queue_membership_intervals(session, start, end):
-    query = '''\
+    return _get_open_close_intervals_by_queue(
+        session,
+        start,
+        end,
+        open_event='ADDMEMBER',
+        close_event='REMOVEMEMBER',
+        agent_join=_AGENT_NAME_OR_INTERFACE_JOIN,
+    )
+
+
+def _get_open_close_intervals_by_queue(
+    session, start, end, open_event, close_event, agent_join
+):
+    open_at_start_query = f'''\
 SELECT
     agent_id,
     queue_name,
-    event_time,
-    event_type,
-    LEAD(event_time) OVER w AS next_event_time
+    MAX(CASE WHEN event_type = :open_event THEN event_time END) AS last_open,
+    MAX(CASE WHEN event_type = :close_event THEN event_time END) AS last_close
 FROM (
     SELECT
         stat_agent.id AS agent_id,
@@ -305,34 +296,53 @@ FROM (
         queue_log.event AS event_type
     FROM queue_log
     JOIN stat_agent ON (
-        stat_agent.name = queue_log.agent
-        OR stat_agent.agent_id = CAST(
-            substring(queue_log.agent FROM '^Local/id-([0-9]+)@agentcallback') AS INTEGER
-        )
+        {agent_join}
     )
-    WHERE queue_log.event IN ('ADDMEMBER', 'REMOVEMEMBER')
-    AND queue_log.time < :end
-) membership_events
-WINDOW w AS (PARTITION BY agent_id, queue_name ORDER BY event_time)
-ORDER BY agent_id, queue_name, event_time
+    WHERE queue_log.event IN (:open_event, :close_event)
+    AND queue_log.time < :start
+) past_events
+GROUP BY agent_id, queue_name
 '''
-    formatted_start = start.strftime(_STR_TIME_FMT)
-    formatted_end = end.strftime(_STR_TIME_FMT)
-    rows = session.execute(
-        text(query),
-        {'start': formatted_start, 'end': formatted_end},
-    )
+    in_range_query = f'''\
+SELECT
+    stat_agent.id AS agent_id,
+    queue_log.queuename AS queue_name,
+    queue_log.time AS event_time,
+    queue_log.event AS event_type
+FROM queue_log
+JOIN stat_agent ON (
+    {agent_join}
+)
+WHERE queue_log.event IN (:open_event, :close_event)
+AND queue_log.time >= :start
+AND queue_log.time < :end
+ORDER BY stat_agent.id, queue_log.queuename, queue_log.time
+'''
+    state_params = {
+        'start': start.strftime(_STR_TIME_FMT),
+        'open_event': open_event,
+        'close_event': close_event,
+    }
+    range_params = {**state_params, 'end': end.strftime(_STR_TIME_FMT)}
+
+    open_since = {}
+    for row in session.execute(text(open_at_start_query), state_params):
+        if row.last_open is None:
+            continue
+        if row.last_close is None or row.last_close < row.last_open:
+            open_since[(row.agent_id, row.queue_name)] = start
 
     intervals = {}
-    for row in rows:
-        if row.event_type != 'ADDMEMBER':
-            continue
-        interval_start = max(row.event_time, start)
-        interval_end = min(row.next_event_time or end, end)
-        if interval_end <= interval_start:
-            continue
+    for row in session.execute(text(in_range_query), range_params):
         key = (row.agent_id, row.queue_name)
-        intervals.setdefault(key, []).append((interval_start, interval_end))
+        if row.event_type == open_event:
+            open_since.setdefault(key, row.event_time)
+        elif key in open_since:
+            opened_at = open_since.pop(key)
+            if opened_at < row.event_time:
+                intervals.setdefault(key, []).append((opened_at, row.event_time))
+    for key, opened_at in open_since.items():
+        intervals.setdefault(key, []).append((opened_at, end))
     return intervals
 
 
@@ -379,6 +389,23 @@ def _filter_overlap(items):
             if not stack:
                 result.append((start, end))
 
+    return result
+
+
+def _intersect_intervals(first, second):
+    first = sorted(first)
+    second = sorted(second)
+    result = []
+    i = j = 0
+    while i < len(first) and j < len(second):
+        start = max(first[i][0], second[j][0])
+        end = min(first[i][1], second[j][1])
+        if start < end:
+            result.append((start, end))
+        if first[i][1] < second[j][1]:
+            i += 1
+        else:
+            j += 1
     return result
 
 

--- a/xivo_dao/stat_dao.py
+++ b/xivo_dao/stat_dao.py
@@ -321,13 +321,15 @@ ORDER BY stat_agent.id, queue_log.queuename, queue_log.time
 
     open_since = {}
     for row in session.execute(text(open_at_start_query), state_params):
-        if row.last_open is None:
+        if row.queue_name is None or row.last_open is None:
             continue
         if row.last_close is None or row.last_close < row.last_open:
             open_since[(row.agent_id, row.queue_name)] = start
 
     intervals = {}
     for row in session.execute(text(in_range_query), range_params):
+        if row.queue_name is None:
+            continue
         key = (row.agent_id, row.queue_name)
         if row.event_type == open_event:
             open_since.setdefault(key, row.event_time)

--- a/xivo_dao/stat_dao.py
+++ b/xivo_dao/stat_dao.py
@@ -177,8 +177,8 @@ SELECT stat_agent.id AS agent,
   GROUP BY stat_agent.id, unpauseall
 '''
 
-    start = start.strftime(_STR_TIME_FMT)
-    end = end.strftime(_STR_TIME_FMT)
+    formatted_start = start.strftime(_STR_TIME_FMT)
+    formatted_end = end.strftime(_STR_TIME_FMT)
 
     rows = (
         session.query(
@@ -187,7 +187,7 @@ SELECT stat_agent.id AS agent,
             literal_column('unpauseall'),
         )
         .from_statement(text(pause_in_range))
-        .params(start=start, end=end)
+        .params(start=formatted_start, end=formatted_end)
     )
 
     results = {}

--- a/xivo_dao/stat_dao.py
+++ b/xivo_dao/stat_dao.py
@@ -191,6 +191,7 @@ SELECT stat_agent.id AS agent,
     )
 
     results = {}
+    pauseall_by_agent = {}
 
     for row in rows.all():
         key = (row.agent, None)
@@ -198,8 +199,73 @@ SELECT stat_agent.id AS agent,
             results[key] = []
 
         results[key].append((row.pauseall, row.unpauseall))
+        pauseall_by_agent.setdefault(row.agent, []).append(
+            (row.pauseall, row.unpauseall)
+        )
+
+    per_queue = _get_per_queue_pause_intervals(session, start, end)
+
+    membership = _get_agent_queue_membership_intervals(session, start, end)
+    for (agent_id, queue_name), member_intervals in membership.items():
+        for pa_start, pa_end in pauseall_by_agent.get(agent_id, []):
+            pa_end_eff = pa_end if pa_end is not None else end
+            for m_start, m_end in member_intervals:
+                overlap_start = max(pa_start, m_start)
+                overlap_end = min(pa_end_eff, m_end)
+                if overlap_end > overlap_start:
+                    per_queue.setdefault((agent_id, queue_name), []).append(
+                        (overlap_start, overlap_end)
+                    )
+
+    for key, intervals in per_queue.items():
+        if len(intervals) > 1:
+            results[key] = _filter_overlap(intervals)
+        else:
+            results[key] = intervals
 
     return results
+
+
+def _get_per_queue_pause_intervals(session, start, end):
+    query = '''\
+SELECT
+    agent_id,
+    queue_name,
+    event_time,
+    event_type,
+    LEAD(event_time) OVER w AS next_event_time
+FROM (
+    SELECT
+        stat_agent.id AS agent_id,
+        queue_log.queuename AS queue_name,
+        queue_log.time AS event_time,
+        queue_log.event AS event_type
+    FROM queue_log
+    JOIN stat_agent ON stat_agent.name = queue_log.agent
+    WHERE queue_log.event IN ('PAUSE', 'UNPAUSE')
+    AND queue_log.time < :end
+) pause_events
+WINDOW w AS (PARTITION BY agent_id, queue_name ORDER BY event_time)
+ORDER BY agent_id, queue_name, event_time
+'''
+    formatted_start = start.strftime(_STR_TIME_FMT)
+    formatted_end = end.strftime(_STR_TIME_FMT)
+    rows = session.execute(
+        text(query),
+        {'start': formatted_start, 'end': formatted_end},
+    )
+
+    intervals = {}
+    for row in rows:
+        if row.event_type != 'PAUSE':
+            continue
+        interval_start = max(row.event_time, start)
+        interval_end = min(row.next_event_time or end, end)
+        if interval_end <= interval_start:
+            continue
+        key = (row.agent_id, row.queue_name)
+        intervals.setdefault(key, []).append((interval_start, interval_end))
+    return intervals
 
 
 def get_login_intervals_in_range(session, start, end):

--- a/xivo_dao/tests/test_queue_log_dao.py
+++ b/xivo_dao/tests/test_queue_log_dao.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import random
@@ -162,12 +162,16 @@ class TestQueueLogDAO(DAOTestCase):
 
         expected = {
             datetime(2012, 10, 1, 6, tzinfo=UTC): {
-                agent_id_1: {'wrapup_time': timedelta(seconds=45)},
-                agent_id_2: {'wrapup_time': timedelta(seconds=30)},
+                (agent_id_1, None): {'wrapup_time': timedelta(seconds=45)},
+                (agent_id_1, 'NONE'): {'wrapup_time': timedelta(seconds=45)},
+                (agent_id_2, None): {'wrapup_time': timedelta(seconds=30)},
+                (agent_id_2, 'NONE'): {'wrapup_time': timedelta(seconds=30)},
             },
             datetime(2012, 10, 1, 7, tzinfo=UTC): {
-                agent_id_1: {'wrapup_time': timedelta(seconds=35)},
-                agent_id_2: {'wrapup_time': timedelta(seconds=20)},
+                (agent_id_1, None): {'wrapup_time': timedelta(seconds=35)},
+                (agent_id_1, 'NONE'): {'wrapup_time': timedelta(seconds=35)},
+                (agent_id_2, None): {'wrapup_time': timedelta(seconds=20)},
+                (agent_id_2, 'NONE'): {'wrapup_time': timedelta(seconds=20)},
             },
         }
 

--- a/xivo_dao/tests/test_queue_log_dao.py
+++ b/xivo_dao/tests/test_queue_log_dao.py
@@ -177,6 +177,25 @@ class TestQueueLogDAO(DAOTestCase):
 
         assert result == expected
 
+    def test_get_wrapup_time_with_null_queuename(self):
+        _, agent_id = self._insert_agent('Agent/1')
+        start = datetime(2012, 10, 1, 6, tzinfo=UTC)
+        end = datetime(2012, 10, 1, 6, 59, 59, 999999, tzinfo=UTC)
+        wrapup_time = self._build_timestamp(datetime(2012, 10, 1, 6, 0, 10, tzinfo=UTC))
+        self._insert_entry_queue(
+            'WRAPUPSTART', wrapup_time, 'NONE', None, agent='Agent/1', d1='15'
+        )
+
+        result = queue_log_dao.get_wrapup_times(self.session, start, end, ONE_HOUR)
+
+        expected = {
+            datetime(2012, 10, 1, 6, tzinfo=UTC): {
+                (agent_id, None): {'wrapup_time': timedelta(seconds=15)},
+            },
+        }
+
+        assert result == expected
+
     def test_get_first_time(self):
         self.assertRaises(LookupError, queue_log_dao.get_first_time, self.session)
 

--- a/xivo_dao/tests/test_stat_agent_periodic_dao.py
+++ b/xivo_dao/tests/test_stat_agent_periodic_dao.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from datetime import datetime as dt
@@ -10,6 +10,7 @@ from sqlalchemy import func
 from xivo_dao import stat_agent_periodic_dao
 from xivo_dao.alchemy.stat_agent import StatAgent
 from xivo_dao.alchemy.stat_agent_periodic import StatAgentPeriodic
+from xivo_dao.alchemy.stat_queue import StatQueue
 from xivo_dao.helpers.db_utils import flush_session
 from xivo_dao.tests.test_dao import DAOTestCase
 
@@ -26,35 +27,42 @@ class TestStatAgentPeriodicDAO(DAOTestCase):
 
         return agent.name, agent.id
 
+    def _insert_queue_to_stat_queue(self, name='test_queue'):
+        queue = StatQueue()
+        queue.name = name
+        queue.tenant_uuid = self.default_tenant.uuid
+        self.add_me(queue)
+        return queue.name, queue.id
+
     def test_insert_periodic_stat(self):
         _, agent_id_1 = self._insert_agent_to_stat_agent()
         _, agent_id_2 = self._insert_agent_to_stat_agent()
         stats = {
             dt(2012, 1, 1, 1, 0, 0, tzinfo=UTC): {
-                agent_id_1: {
+                (agent_id_1, None): {
                     'login_time': timedelta(minutes=50),
                     'pause_time': timedelta(minutes=13),
                 },
-                agent_id_2: {
+                (agent_id_2, None): {
                     'login_time': ONE_HOUR,
                     'pause_time': timedelta(minutes=13),
                 },
             },
             dt(2012, 1, 1, 2, 0, 0, tzinfo=UTC): {
-                agent_id_1: {
+                (agent_id_1, None): {
                     'login_time': timedelta(minutes=20),
                     'pause_time': timedelta(minutes=33),
                 },
-                agent_id_2: {
+                (agent_id_2, None): {
                     'login_time': ONE_HOUR,
                     'pause_time': timedelta(minutes=13),
                 },
             },
             dt(2012, 1, 1, 3, 0, 0, tzinfo=UTC): {
-                agent_id_2: {'login_time': ONE_HOUR, 'pause_time': ONE_HOUR},
+                (agent_id_2, None): {'login_time': ONE_HOUR, 'pause_time': ONE_HOUR},
             },
             dt(2012, 1, 1, 4, 0, 0, tzinfo=UTC): {
-                agent_id_2: {'login_time': ONE_HOUR, 'pause_time': ONE_HOUR},
+                (agent_id_2, None): {'login_time': ONE_HOUR, 'pause_time': ONE_HOUR},
             },
         }
 
@@ -74,13 +82,56 @@ class TestStatAgentPeriodicDAO(DAOTestCase):
             )
 
             assert result.login_time == timedelta(minutes=50)
+            assert result.stat_queue_id is None
         except LookupError:
             self.fail('Should have found a row')
+
+    def test_insert_periodic_stat_with_per_queue_row(self):
+        _, agent_id = self._insert_agent_to_stat_agent()
+        _, queue_id = self._insert_queue_to_stat_queue()
+        period_start = dt(2012, 1, 1, 1, 0, 0, tzinfo=UTC)
+        stats = {
+            (agent_id, None): {
+                'login_time': ONE_HOUR,
+                'pause_time': timedelta(minutes=5),
+                'wrapup_time': timedelta(minutes=2),
+            },
+            (agent_id, queue_id): {
+                'login_time': timedelta(minutes=30),
+                'wrapup_time': timedelta(minutes=1),
+            },
+        }
+
+        with flush_session(self.session):
+            stat_agent_periodic_dao.insert_stats(self.session, stats, period_start)
+
+        rows = (
+            self.session.query(StatAgentPeriodic)
+            .filter(StatAgentPeriodic.time == period_start)
+            .filter(StatAgentPeriodic.stat_agent_id == agent_id)
+            .order_by(StatAgentPeriodic.stat_queue_id.nullsfirst())
+            .all()
+        )
+
+        assert len(rows) == 2
+
+        global_row, queue_row = rows
+        assert global_row.stat_queue_id is None
+        assert global_row.login_time == ONE_HOUR
+        assert global_row.pause_time == timedelta(minutes=5)
+
+        assert queue_row.stat_queue_id == queue_id
+        assert queue_row.login_time == timedelta(minutes=30)
+        assert queue_row.pause_time == timedelta(0)
+        assert queue_row.wrapup_time == timedelta(minutes=1)
 
     def test_clean_table(self):
         _, agent_id = self._insert_agent_to_stat_agent()
         stats = {
-            agent_id: {'login_time': timedelta(minutes=15), 'pause_time': ONE_HOUR},
+            (agent_id, None): {
+                'login_time': timedelta(minutes=15),
+                'pause_time': ONE_HOUR,
+            },
         }
 
         stat_agent_periodic_dao.insert_stats(
@@ -97,19 +148,19 @@ class TestStatAgentPeriodicDAO(DAOTestCase):
         _, agent_id = self._insert_agent_to_stat_agent()
         stats = {
             dt(2012, 1, 1, tzinfo=UTC): {
-                agent_id: {
+                (agent_id, None): {
                     'login_time': timedelta(minutes=15),
                     'pause_time': timedelta(minutes=13),
                 },
             },
             dt(2012, 1, 2, tzinfo=UTC): {
-                agent_id: {
+                (agent_id, None): {
                     'login_time': timedelta(minutes=20),
                     'pause_time': timedelta(minutes=13),
                 },
             },
             dt(2012, 1, 3, tzinfo=UTC): {
-                agent_id: {
+                (agent_id, None): {
                     'login_time': timedelta(minutes=25),
                     'pause_time': timedelta(minutes=13),
                 },

--- a/xivo_dao/tests/test_stat_dao.py
+++ b/xivo_dao/tests/test_stat_dao.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import datetime
@@ -402,7 +402,7 @@ class TestStatDAO(DAOTestCase):
             self.session, self.start, self.end
         )
 
-        expected = {self.aid1: sorted([(logins[0]['time'], self.end)])}
+        expected = {(self.aid1, None): sorted([(logins[0]['time'], self.end)])}
 
         assert expected == result
 
@@ -501,7 +501,7 @@ class TestStatDAO(DAOTestCase):
             self.session, self.start, self.end
         )
 
-        expected = {self.aid1: sorted([(logintime, logouttime)])}
+        expected = {(self.aid1, None): sorted([(logintime, logouttime)])}
 
         assert expected == result
 
@@ -557,7 +557,7 @@ class TestStatDAO(DAOTestCase):
             self.session, self.start, self.end
         )
 
-        expected = {self.aid1: sorted([(logintime, logouttime)])}
+        expected = {(self.aid1, None): sorted([(logintime, logouttime)])}
 
         assert expected == result
 
@@ -616,7 +616,7 @@ class TestStatDAO(DAOTestCase):
         )
 
         expected = {
-            self.aid1: sorted(
+            (self.aid1, None): sorted(
                 [
                     (cb_logins[0]['time'], cb_logoffs[0]['time']),
                     (cb_logins[1]['time'], cb_logoffs[1]['time']),
@@ -654,7 +654,7 @@ class TestStatDAO(DAOTestCase):
         )
 
         expected = {
-            self.aid1: [(self.start, self.end)],
+            (self.aid1, None): [(self.start, self.end)],
         }
 
         assert expected == result

--- a/xivo_dao/tests/test_stat_dao_extended.py
+++ b/xivo_dao/tests/test_stat_dao_extended.py
@@ -464,6 +464,40 @@ class TestStatDAO(DAOTestCase):
             ),
         ]
 
+    def test_get_pause_intervals_in_range_ignores_null_queuename(self):
+        # queue_log.queuename is nullable: a NULL queuename must not become a
+        # per-queue key that collides with the global (agent, None) entry.
+        _, agent_pk = self._insert_agent('Agent/1')
+        start = dt(2012, 7, 1, tzinfo=UTC)
+        end = dt(2012, 7, 31, 23, 59, 59, 999999, tzinfo=UTC)
+
+        queue_log_data = '''\
+| time                          | callid | queuename | agent   | event      | data1 | data2 | data3 | data4 | data5 |
+| 2012-07-21 09:00:00.000000+00 | NONE   | NONE      | Agent/1 | PAUSEALL   |       |       |       |       |       |
+| 2012-07-21 09:30:00.000000+00 | NONE   | NONE      | Agent/1 | UNPAUSEALL |       |       |       |       |       |
+'''
+
+        self._insert_queue_log_data(queue_log_data)
+        with flush_session(self.session):
+            self.session.add(
+                QueueLog(
+                    time=dt(2012, 7, 21, 10, 0, 0, tzinfo=UTC),
+                    callid='NONE',
+                    queuename=None,
+                    agent='Agent/1',
+                    event='PAUSE',
+                )
+            )
+
+        result = stat_dao.get_pause_intervals_in_range(self.session, start, end)
+
+        assert result[(agent_pk, None)] == [
+            (
+                dt(2012, 7, 21, 9, 0, 0, tzinfo=UTC),
+                dt(2012, 7, 21, 9, 30, 0, tzinfo=UTC),
+            ),
+        ]
+
     def test_get_pause_intervals_in_range_per_queue_via_interface(self):
         # Depending on Asterisk's 'log_membername_as_agent' option, PAUSE and
         # UNPAUSE can carry the channel interface instead of the agent name.

--- a/xivo_dao/tests/test_stat_dao_extended.py
+++ b/xivo_dao/tests/test_stat_dao_extended.py
@@ -473,9 +473,10 @@ class TestStatDAO(DAOTestCase):
         end = dt(2012, 7, 31, 23, 59, 59, 999999, tzinfo=UTC)
 
         queue_log_data = '''\
-| time                          | callid | queuename | agent                     | event        | data1 | data2 | data3 | data4 | data5 |
-| 2012-07-21 08:00:00.000000+00 | NONE   | queue_a   | Local/id-61@agentcallback | ADDMEMBER    |       |       |       |       |       |
-| 2012-07-21 12:00:00.000000+00 | NONE   | queue_a   | Local/id-61@agentcallback | REMOVEMEMBER |       |       |       |       |       |
+| time                          | callid | queuename | agent                     | event              | data1 | data2 | data3 | data4 | data5 |
+| 2012-07-21 07:55:00.000000+00 | NONE   | NONE      | Agent/52                  | AGENTCALLBACKLOGIN |       |       |       |       |       |
+| 2012-07-21 08:00:00.000000+00 | NONE   | queue_a   | Local/id-61@agentcallback | ADDMEMBER          |       |       |       |       |       |
+| 2012-07-21 12:00:00.000000+00 | NONE   | queue_a   | Local/id-61@agentcallback | REMOVEMEMBER       |       |       |       |       |       |
 '''
 
         self._insert_queue_log_data(queue_log_data)
@@ -496,9 +497,10 @@ class TestStatDAO(DAOTestCase):
         end = dt(2012, 7, 31, 23, 59, 59, 999999, tzinfo=UTC)
 
         queue_log_data = '''\
-| time                          | callid | queuename | agent    | event        | data1 | data2 | data3 | data4 | data5 |
-| 2012-07-21 08:00:00.000000+00 | NONE   | queue_a   | Agent/52 | ADDMEMBER    |       |       |       |       |       |
-| 2012-07-21 12:00:00.000000+00 | NONE   | queue_a   | Agent/52 | REMOVEMEMBER |       |       |       |       |       |
+| time                          | callid | queuename | agent    | event              | data1 | data2 | data3 | data4 | data5 |
+| 2012-07-21 07:55:00.000000+00 | NONE   | NONE      | Agent/52 | AGENTCALLBACKLOGIN |       |       |       |       |       |
+| 2012-07-21 08:00:00.000000+00 | NONE   | queue_a   | Agent/52 | ADDMEMBER          |       |       |       |       |       |
+| 2012-07-21 12:00:00.000000+00 | NONE   | queue_a   | Agent/52 | REMOVEMEMBER       |       |       |       |       |       |
 '''
 
         self._insert_queue_log_data(queue_log_data)
@@ -509,6 +511,100 @@ class TestStatDAO(DAOTestCase):
             (
                 dt(2012, 7, 21, 8, 0, 0, tzinfo=UTC),
                 dt(2012, 7, 21, 12, 0, 0, tzinfo=UTC),
+            ),
+        ]
+
+    def test_get_login_intervals_in_range_per_queue_without_global_login(self):
+        # Per-queue login is global login ∩ membership: membership events
+        # alone must not produce per-queue login time.
+        _, agent_pk = self._insert_agent('Agent/52', agent_id=61)
+        start = dt(2012, 7, 1, tzinfo=UTC)
+        end = dt(2012, 7, 31, 23, 59, 59, 999999, tzinfo=UTC)
+
+        queue_log_data = '''\
+| time                          | callid | queuename | agent    | event        | data1 | data2 | data3 | data4 | data5 |
+| 2012-07-21 08:00:00.000000+00 | NONE   | queue_a   | Agent/52 | ADDMEMBER    |       |       |       |       |       |
+| 2012-07-21 12:00:00.000000+00 | NONE   | queue_a   | Agent/52 | REMOVEMEMBER |       |       |       |       |       |
+'''
+
+        self._insert_queue_log_data(queue_log_data)
+
+        result = stat_dao.get_login_intervals_in_range(self.session, start, end)
+
+        assert (agent_pk, 'queue_a') not in result
+
+    def test_get_login_intervals_in_range_per_queue_clipped_by_global_logoff(self):
+        # A membership left open (missing REMOVEMEMBER) must not extend past
+        # the agent's global logoff.
+        _, agent_pk = self._insert_agent('Agent/52', agent_id=61)
+        context = self.add_context()
+        start = dt(2012, 7, 1, tzinfo=UTC)
+        end = dt(2012, 7, 31, 23, 59, 59, 999999, tzinfo=UTC)
+
+        queue_log_data = f'''\
+| time                          | callid | queuename | agent    | event               | data1               | data2 | data3 | data4 | data5 |
+| 2012-07-21 08:00:00.000000+00 | NONE   | NONE      | Agent/52 | AGENTCALLBACKLOGIN  | 1000@{context.name} |       |       |       |       |
+| 2012-07-21 08:00:00.000000+00 | NONE   | queue_a   | Agent/52 | ADDMEMBER           |                     |       |       |       |       |
+| 2012-07-21 10:00:00.000000+00 | NONE   | NONE      | Agent/52 | AGENTCALLBACKLOGOFF | 1000@{context.name} | 7200  |       |       |       |
+'''
+
+        self._insert_queue_log_data(queue_log_data)
+
+        result = stat_dao.get_login_intervals_in_range(self.session, start, end)
+
+        assert result[(agent_pk, 'queue_a')] == [
+            (
+                dt(2012, 7, 21, 8, 0, 0, tzinfo=UTC),
+                dt(2012, 7, 21, 10, 0, 0, tzinfo=UTC),
+            ),
+        ]
+
+    def test_get_login_intervals_in_range_per_queue_membership_open_at_start(self):
+        # An ADDMEMBER before the range with no RE-ADD in range must still
+        # count: the membership is open when the range starts.
+        _, agent_pk = self._insert_agent('Agent/52', agent_id=61)
+        start = dt(2012, 7, 1, tzinfo=UTC)
+        end = dt(2012, 7, 31, 23, 59, 59, 999999, tzinfo=UTC)
+
+        queue_log_data = '''\
+| time                          | callid | queuename | agent    | event              | data1 | data2 | data3 | data4 | data5 |
+| 2012-06-30 07:55:00.000000+00 | NONE   | NONE      | Agent/52 | AGENTCALLBACKLOGIN |       |       |       |       |       |
+| 2012-06-30 08:00:00.000000+00 | NONE   | queue_a   | Agent/52 | ADDMEMBER          |       |       |       |       |       |
+| 2012-07-21 12:00:00.000000+00 | NONE   | queue_a   | Agent/52 | REMOVEMEMBER       |       |       |       |       |       |
+'''
+
+        self._insert_queue_log_data(queue_log_data)
+
+        result = stat_dao.get_login_intervals_in_range(self.session, start, end)
+
+        assert result[(agent_pk, 'queue_a')] == [
+            (
+                start,
+                dt(2012, 7, 21, 12, 0, 0, tzinfo=UTC),
+            ),
+        ]
+
+    def test_get_pause_intervals_in_range_per_queue_pause_open_at_start(self):
+        # A PAUSE before the range with the UNPAUSE in range must count from
+        # the range start.
+        _, agent_id_1 = self._insert_agent('Agent/1')
+        start = dt(2012, 7, 1, tzinfo=UTC)
+        end = dt(2012, 7, 31, 23, 59, 59, 999999, tzinfo=UTC)
+
+        queue_log_data = '''\
+| time                          | callid | queuename | agent   | event   | data1 | data2 | data3 | data4 | data5 |
+| 2012-06-30 09:00:00.000000+00 | NONE   | queue_a   | Agent/1 | PAUSE   |       |       |       |       |       |
+| 2012-07-21 10:00:00.000000+00 | NONE   | queue_a   | Agent/1 | UNPAUSE |       |       |       |       |       |
+'''
+
+        self._insert_queue_log_data(queue_log_data)
+
+        result = stat_dao.get_pause_intervals_in_range(self.session, start, end)
+
+        assert result[(agent_id_1, 'queue_a')] == [
+            (
+                start,
+                dt(2012, 7, 21, 10, 0, 0, tzinfo=UTC),
             ),
         ]
 

--- a/xivo_dao/tests/test_stat_dao_extended.py
+++ b/xivo_dao/tests/test_stat_dao_extended.py
@@ -464,6 +464,54 @@ class TestStatDAO(DAOTestCase):
             ),
         ]
 
+    def test_get_login_intervals_in_range_per_queue_via_interface(self):
+        # Asterisk logs ADDMEMBER/REMOVEMEMBER with the member *interface*
+        # (Local/id-<agent.id>@agentcallback), not the membername (Agent/<number>).
+        # The per-queue login must still resolve to the right agent.
+        _, agent_pk = self._insert_agent('Agent/52', agent_id=61)
+        start = dt(2012, 7, 1, tzinfo=UTC)
+        end = dt(2012, 7, 31, 23, 59, 59, 999999, tzinfo=UTC)
+
+        queue_log_data = '''\
+| time                          | callid | queuename | agent                     | event        | data1 | data2 | data3 | data4 | data5 |
+| 2012-07-21 08:00:00.000000+00 | NONE   | queue_a   | Local/id-61@agentcallback | ADDMEMBER    |       |       |       |       |       |
+| 2012-07-21 12:00:00.000000+00 | NONE   | queue_a   | Local/id-61@agentcallback | REMOVEMEMBER |       |       |       |       |       |
+'''
+
+        self._insert_queue_log_data(queue_log_data)
+
+        result = stat_dao.get_login_intervals_in_range(self.session, start, end)
+
+        assert result[(agent_pk, 'queue_a')] == [
+            (
+                dt(2012, 7, 21, 8, 0, 0, tzinfo=UTC),
+                dt(2012, 7, 21, 12, 0, 0, tzinfo=UTC),
+            ),
+        ]
+
+    def test_get_login_intervals_in_range_per_queue_via_membername(self):
+        # Back-compat: events logged with the membername must still resolve.
+        _, agent_pk = self._insert_agent('Agent/52', agent_id=61)
+        start = dt(2012, 7, 1, tzinfo=UTC)
+        end = dt(2012, 7, 31, 23, 59, 59, 999999, tzinfo=UTC)
+
+        queue_log_data = '''\
+| time                          | callid | queuename | agent    | event        | data1 | data2 | data3 | data4 | data5 |
+| 2012-07-21 08:00:00.000000+00 | NONE   | queue_a   | Agent/52 | ADDMEMBER    |       |       |       |       |       |
+| 2012-07-21 12:00:00.000000+00 | NONE   | queue_a   | Agent/52 | REMOVEMEMBER |       |       |       |       |       |
+'''
+
+        self._insert_queue_log_data(queue_log_data)
+
+        result = stat_dao.get_login_intervals_in_range(self.session, start, end)
+
+        assert result[(agent_pk, 'queue_a')] == [
+            (
+                dt(2012, 7, 21, 8, 0, 0, tzinfo=UTC),
+                dt(2012, 7, 21, 12, 0, 0, tzinfo=UTC),
+            ),
+        ]
+
     def _insert_queue_log_data(self, queue_log_data):
         with flush_session(self.session):
             logs = parse_table(queue_log_data)
@@ -472,9 +520,9 @@ class TestStatDAO(DAOTestCase):
         self.session.expire_all()
         return queue_logs
 
-    def _insert_agent(self, aname, tenant_uuid=None):
+    def _insert_agent(self, aname, tenant_uuid=None, agent_id=None):
         tenant_uuid = tenant_uuid or self.default_tenant.uuid
-        a = StatAgent(name=aname, tenant_uuid=tenant_uuid)
+        a = StatAgent(name=aname, tenant_uuid=tenant_uuid, agent_id=agent_id)
 
         self.add_me(a)
 

--- a/xivo_dao/tests/test_stat_dao_extended.py
+++ b/xivo_dao/tests/test_stat_dao_extended.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
@@ -324,7 +324,7 @@ class TestStatDAO(DAOTestCase):
             result[agent] = sorted(logins, key=lambda login: login[0])
 
         expected = {
-            agent_id_1: [
+            (agent_id_1, None): [
                 (
                     dt(2012, 7, 21, 9, 59, 9, 999999, tzinfo=UTC),
                     dt(2012, 7, 21, 10, 54, 9, 999999, tzinfo=UTC),
@@ -359,7 +359,7 @@ class TestStatDAO(DAOTestCase):
             result[agent] = sorted(logins, key=lambda login: login[0])
 
         expected = {
-            agent_id_1: [
+            (agent_id_1, None): [
                 (
                     dt(2012, 7, 21, 9, 54, 9, 999999, tzinfo=UTC),
                     dt(2012, 7, 21, 10, 54, 9, 999999, tzinfo=UTC),

--- a/xivo_dao/tests/test_stat_dao_extended.py
+++ b/xivo_dao/tests/test_stat_dao_extended.py
@@ -373,6 +373,97 @@ class TestStatDAO(DAOTestCase):
 
         assert result == expected
 
+    def test_get_pause_intervals_in_range_per_queue(self):
+        _, agent_id_1 = self._insert_agent('Agent/1')
+        start = dt(2012, 7, 1, tzinfo=UTC)
+        end = dt(2012, 7, 31, 23, 59, 59, 999999, tzinfo=UTC)
+
+        queue_log_data = '''\
+| time                          | callid | queuename | agent   | event   | data1 | data2 | data3 | data4 | data5 |
+| 2012-07-21 09:00:00.000000+00 | NONE   | queue_a   | Agent/1 | PAUSE   |       |       |       |       |       |
+| 2012-07-21 09:30:00.000000+00 | NONE   | queue_a   | Agent/1 | UNPAUSE |       |       |       |       |       |
+| 2012-07-22 10:00:00.000000+00 | NONE   | queue_b   | Agent/1 | PAUSE   |       |       |       |       |       |
+| 2012-07-22 10:15:00.000000+00 | NONE   | queue_b   | Agent/1 | UNPAUSE |       |       |       |       |       |
+'''
+
+        self._insert_queue_log_data(queue_log_data)
+
+        result = stat_dao.get_pause_intervals_in_range(self.session, start, end)
+
+        expected = {
+            (agent_id_1, 'queue_a'): [
+                (
+                    dt(2012, 7, 21, 9, 0, 0, tzinfo=UTC),
+                    dt(2012, 7, 21, 9, 30, 0, tzinfo=UTC),
+                ),
+            ],
+            (agent_id_1, 'queue_b'): [
+                (
+                    dt(2012, 7, 22, 10, 0, 0, tzinfo=UTC),
+                    dt(2012, 7, 22, 10, 15, 0, tzinfo=UTC),
+                ),
+            ],
+        }
+
+        assert expected == result
+
+    def test_get_pause_intervals_in_range_pauseall_intersect_membership(self):
+        _, agent_id_1 = self._insert_agent('Agent/1')
+        start = dt(2012, 7, 1, tzinfo=UTC)
+        end = dt(2012, 7, 31, 23, 59, 59, 999999, tzinfo=UTC)
+
+        queue_log_data = '''\
+| time                          | callid | queuename | agent   | event        | data1 | data2 | data3 | data4 | data5 |
+| 2012-07-21 08:00:00.000000+00 | NONE   | queue_a   | Agent/1 | ADDMEMBER    |       |       |       |       |       |
+| 2012-07-21 08:00:00.000000+00 | NONE   | queue_b   | Agent/1 | ADDMEMBER    |       |       |       |       |       |
+| 2012-07-21 09:00:00.000000+00 | NONE   | NONE      | Agent/1 | PAUSEALL     |       |       |       |       |       |
+| 2012-07-21 09:30:00.000000+00 | NONE   | NONE      | Agent/1 | UNPAUSEALL   |       |       |       |       |       |
+| 2012-07-21 12:00:00.000000+00 | NONE   | queue_b   | Agent/1 | REMOVEMEMBER |       |       |       |       |       |
+'''
+
+        self._insert_queue_log_data(queue_log_data)
+
+        result = stat_dao.get_pause_intervals_in_range(self.session, start, end)
+        for key in result:
+            result[key] = sorted(result[key], key=lambda interval: interval[0])
+
+        pauseall_interval = (
+            dt(2012, 7, 21, 9, 0, 0, tzinfo=UTC),
+            dt(2012, 7, 21, 9, 30, 0, tzinfo=UTC),
+        )
+        expected = {
+            (agent_id_1, None): [pauseall_interval],
+            (agent_id_1, 'queue_a'): [pauseall_interval],
+            (agent_id_1, 'queue_b'): [pauseall_interval],
+        }
+
+        assert expected == result
+
+    def test_get_pause_intervals_in_range_merges_per_queue_and_pauseall(self):
+        _, agent_id_1 = self._insert_agent('Agent/1')
+        start = dt(2012, 7, 1, tzinfo=UTC)
+        end = dt(2012, 7, 31, 23, 59, 59, 999999, tzinfo=UTC)
+
+        queue_log_data = '''\
+| time                          | callid | queuename | agent   | event      | data1 | data2 | data3 | data4 | data5 |
+| 2012-07-21 08:00:00.000000+00 | NONE   | queue_a   | Agent/1 | ADDMEMBER  |       |       |       |       |       |
+| 2012-07-21 09:00:00.000000+00 | NONE   | queue_a   | Agent/1 | PAUSE      |       |       |       |       |       |
+| 2012-07-21 09:15:00.000000+00 | NONE   | NONE      | Agent/1 | PAUSEALL   |       |       |       |       |       |
+| 2012-07-21 09:45:00.000000+00 | NONE   | NONE      | Agent/1 | UNPAUSEALL |       |       |       |       |       |
+| 2012-07-21 10:00:00.000000+00 | NONE   | queue_a   | Agent/1 | UNPAUSE    |       |       |       |       |       |
+'''
+
+        self._insert_queue_log_data(queue_log_data)
+
+        result = stat_dao.get_pause_intervals_in_range(self.session, start, end)
+
+        assert result[(agent_id_1, 'queue_a')] == [
+            (
+                dt(2012, 7, 21, 9, 0, 0, tzinfo=UTC),
+                dt(2012, 7, 21, 10, 0, 0, tzinfo=UTC),
+            ),
+        ]
+
     def _insert_queue_log_data(self, queue_log_data):
         with flush_session(self.session):
             logs = parse_table(queue_log_data)

--- a/xivo_dao/tests/test_stat_dao_extended.py
+++ b/xivo_dao/tests/test_stat_dao_extended.py
@@ -464,6 +464,30 @@ class TestStatDAO(DAOTestCase):
             ),
         ]
 
+    def test_get_pause_intervals_in_range_per_queue_via_interface(self):
+        # Depending on Asterisk's 'log_membername_as_agent' option, PAUSE and
+        # UNPAUSE can carry the channel interface instead of the agent name.
+        _, agent_pk = self._insert_agent('Agent/52', agent_id=61)
+        start = dt(2012, 7, 1, tzinfo=UTC)
+        end = dt(2012, 7, 31, 23, 59, 59, 999999, tzinfo=UTC)
+
+        queue_log_data = '''\
+| time                          | callid | queuename | agent                     | event   | data1 | data2 | data3 | data4 | data5 |
+| 2012-07-21 09:00:00.000000+00 | NONE   | queue_a   | Local/id-61@agentcallback | PAUSE   |       |       |       |       |       |
+| 2012-07-21 09:30:00.000000+00 | NONE   | queue_a   | Local/id-61@agentcallback | UNPAUSE |       |       |       |       |       |
+'''
+
+        self._insert_queue_log_data(queue_log_data)
+
+        result = stat_dao.get_pause_intervals_in_range(self.session, start, end)
+
+        assert result[(agent_pk, 'queue_a')] == [
+            (
+                dt(2012, 7, 21, 9, 0, 0, tzinfo=UTC),
+                dt(2012, 7, 21, 9, 30, 0, tzinfo=UTC),
+            ),
+        ]
+
     def test_get_login_intervals_in_range_per_queue_via_interface(self):
         # Asterisk logs ADDMEMBER/REMOVEMEMBER with the member *interface*
         # (Local/id-<agent.id>@agentcallback), not the membername (Agent/<number>).


### PR DESCRIPTION
- **dao: add queue_id to agent stats**
- **stats: link agent stats to queues**


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how reported agent login/pause/wrapup time is computed and stored; incorrect interval logic would skew operational stats, but scope is stats aggregation rather than call handling or auth.
> 
> **Overview**
> Adds **per-queue agent periodic statistics** alongside existing agent-wide totals.
> 
> `stat_agent_periodic` gains optional `stat_queue_id` (FK + index). DAOs now key metrics by `(agent_id, queue_id_or_name)` instead of agent alone: `insert_stats` writes separate global (`None`) and per-queue rows; `get_wrapup_times` includes queue name and rolls wrapup into both global and queue keys (deduping when `queuename` is NULL).
> 
> `stat_dao` extends login/pause interval logic from queue_log: **ADDMEMBER/REMOVEMEMBER** membership intervals intersect global login time for per-queue login; **PAUSE/UNPAUSE** per queue plus **PAUSEALL** intervals intersected with membership for per-queue pause. Shared `_get_open_close_intervals_by_queue` resolves agents via name or `Local/id-*@agentcallback` interface. NULL `queuename` events are skipped for per-queue keys.
> 
> Tests updated for tuple keys and broad coverage of edge cases (open-at-range-start, logoff clipping, interface vs membername).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f11bcb479ca8c8a61ae4a41fd091dfb493257f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->