### PR TITLE
fix(enum): factor out shared enum queue_category

### DIFF
--- a/xivo_dao/alchemy/enum.py
+++ b/xivo_dao/alchemy/enum.py
@@ -1,9 +1,16 @@
-# Copyright 2014-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2014-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from sqlalchemy.types import Enum
 
 from xivo_dao.helpers.db_manager import Base
+
+queue_category = Enum(
+    'group',
+    'queue',
+    name='queue_category',
+    metadata=Base.metadata,
+)
 
 dialaction_action = Enum(
     'none',

--- a/xivo_dao/alchemy/queue.py
+++ b/xivo_dao/alchemy/queue.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from sqlalchemy.ext.hybrid import hybrid_property
@@ -7,6 +7,7 @@ from sqlalchemy.schema import Column, Index, PrimaryKeyConstraint
 from sqlalchemy.sql.schema import CheckConstraint
 from sqlalchemy.types import Enum, Integer, String, Text
 
+from xivo_dao.alchemy import enum
 from xivo_dao.helpers.asterisk import AsteriskOptionsMixin
 from xivo_dao.helpers.db_manager import Base
 
@@ -77,10 +78,7 @@ class Queue(Base, AsteriskOptionsMixin):
     weight = Column(Integer)
     timeoutrestart = Column(Integer, nullable=False, server_default='0')
     commented = Column(Integer, nullable=False, server_default='0')
-    category = Column(
-        Enum('group', 'queue', name='queue_category', metadata=Base.metadata),
-        nullable=False,
-    )
+    category = Column(enum.queue_category, nullable=False)
     timeoutpriority = Column(String(10), nullable=False, server_default='app')
     autofill = Column(Integer, nullable=False, server_default='1')
     autopause = Column(String(3), nullable=False, server_default='no')

--- a/xivo_dao/alchemy/queuemember.py
+++ b/xivo_dao/alchemy/queuemember.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import re
@@ -9,6 +9,7 @@ from sqlalchemy.orm import relationship
 from sqlalchemy.schema import Column, Index, PrimaryKeyConstraint, UniqueConstraint
 from sqlalchemy.types import Enum, Integer, String
 
+from xivo_dao.alchemy import enum
 from xivo_dao.helpers.db_manager import Base
 
 interface_regex = re.compile(r'Local/(?P<exten>.*)@(?P<context>.*)')
@@ -43,10 +44,7 @@ class QueueMember(Base):
     )
     userid = Column(Integer, nullable=False)
     channel = Column(String(25), nullable=False)
-    category = Column(
-        Enum('queue', 'group', name='queue_category', metadata=Base.metadata),
-        nullable=False,
-    )
+    category = Column(enum.queue_category, nullable=False)
     position = Column(Integer, nullable=False, server_default='0')
 
     agent = relationship(

--- a/xivo_dao/alchemy/tests/test_enum.py
+++ b/xivo_dao/alchemy/tests/test_enum.py
@@ -1,0 +1,27 @@
+# Copyright 2026 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from sqlalchemy.types import Enum
+
+import xivo_dao.alchemy  # noqa: F401 - load every model so all enums register
+from xivo_dao.helpers.db_manager import Base
+
+
+def test_metadata_bound_enums_have_consistent_value_orders():
+    declarations: dict[str, set[tuple[str, ...]]] = {}
+    for table in Base.metadata.tables.values():
+        for column in table.columns:
+            column_type = column.type
+            if isinstance(column_type, Enum) and column_type.name:
+                declarations.setdefault(column_type.name, set()).add(
+                    tuple(column_type.enums)
+                )
+
+    conflicts = {
+        name: orders for name, orders in declarations.items() if len(orders) > 1
+    }
+    assert not conflicts, (
+        "Enum types declared with conflicting value orders across modules; "
+        "define each enum once (e.g. in xivo_dao/alchemy/enum.py) and reuse it: "
+        f"{conflicts}"
+    )

--- a/xivo_dao/alchemy/tests/test_enum.py
+++ b/xivo_dao/alchemy/tests/test_enum.py
@@ -3,7 +3,7 @@
 
 from sqlalchemy.types import Enum
 
-import xivo_dao.alchemy  # noqa: F401 - load every model so all enums register
+import xivo_dao.alchemy.all  # noqa: F401 - load every model so all enums register
 from xivo_dao.helpers.db_manager import Base
 
 


### PR DESCRIPTION
why: avoid schema conflicts from multiple definitions

the two definitions were not declaring the enum members with the same ordering, resulting in different schemas depending on which was imported first

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches SQLAlchemy Enum type declarations used in database schemas; incorrect ordering or reuse could affect migrations/DDL generation across modules, though the change is small and targeted.
> 
> **Overview**
> Centralizes the `queue_category` Enum in `xivo_dao/alchemy/enum.py` and updates `Queue.category` and `QueueMember.category` to reuse this single declaration, eliminating duplicate definitions with differing value orders.
> 
> Adds a regression test (`test_enum.py`) that scans `Base.metadata` for metadata-bound Enums and fails if any Enum type name is declared with multiple, conflicting value orderings across modules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7bede56e8bea5a8784d38a1ab92ba7d957de5949. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->