### PR TITLE
feat(user): add line_presence user view

### DIFF
--- a/xivo_dao/resources/user/model.py
+++ b/xivo_dao/resources/user/model.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
@@ -65,6 +65,17 @@ class UserSummary:
         self.context = context
         self.subscription_type = subscription_type
         self.is_webrtc = is_webrtc
+
+    def __eq__(self, other):
+        return self.__dict__ == other.__dict__
+
+
+class UserLinePresence:
+    def __init__(self, uuid, tenant_uuid, dnd_enabled, lines):
+        self.uuid = uuid
+        self.tenant_uuid = tenant_uuid
+        self.dnd_enabled = dnd_enabled
+        self.lines = lines
 
     def __eq__(self, other):
         return self.__dict__ == other.__dict__

--- a/xivo_dao/resources/user/search.py
+++ b/xivo_dao/resources/user/search.py
@@ -1,7 +1,8 @@
 # Copyright 2014-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from sqlalchemy.sql import and_, or_
+from sqlalchemy import Column
+from sqlalchemy.sql import and_, or_, visitors
 
 from xivo_dao.alchemy.extension import Extension
 from xivo_dao.alchemy.line_extension import LineExtension
@@ -9,6 +10,7 @@ from xivo_dao.alchemy.linefeatures import LineFeatures
 from xivo_dao.alchemy.user_line import UserLine
 from xivo_dao.alchemy.userfeatures import UserFeatures
 from xivo_dao.alchemy.voicemail import Voicemail
+from xivo_dao.helpers import errors
 from xivo_dao.resources.utils.search import SearchConfig, SearchSystem
 
 config = SearchConfig(
@@ -65,6 +67,11 @@ class UserSearchSystem(SearchSystem):
         line_presence_view = parameters.get('view') == 'line_presence'
         searching = bool(parameters.get('search') or parameters.get('exten'))
 
+        if line_presence_view:
+            # params that require additional joins will generate incorrect results
+            # against the line_presence view
+            self._reject_unsupported_line_presence_params(parameters)
+
         if 'uuid' in parameters and isinstance(parameters['uuid'], str):
             uuids = parameters.pop('uuid').split(',')
             query = self._filter_exact_match_uuids(query, uuids)
@@ -84,6 +91,34 @@ class UserSearchSystem(SearchSystem):
             if line_presence_view:
                 query = query.distinct()
         return super().search_from_query(query, parameters)
+
+    def _reject_unsupported_line_presence_params(self, parameters):
+        # `exten` as a filter already forces `_search_on_extension()` via
+        # `searching`, so it's safe here even though it's a joined column.
+        for name, value in parameters.items():
+            if name == 'exten':
+                continue
+            column = self.config.column_for_searching(name)
+            if column is not None and self._requires_extension_join(column):
+                raise errors.invalid_query_parameter(name, value)
+
+        order = parameters.get('order')
+        if order:
+            column = self.config.column_for_searching(order)
+            if column is not None and self._requires_extension_join(column):
+                raise errors.invalid_query_parameter('order', order)
+
+    @staticmethod
+    def _requires_extension_join(column):
+        # need to handle actual Column objects as well as column expressions
+        # which don't have .table
+        table = getattr(column, 'table', None)
+        if table is not None:
+            return table is not UserFeatures.__table__
+        tables = {
+            elem.table for elem in visitors.iterate(column) if isinstance(elem, Column)
+        }
+        return any(table is not UserFeatures.__table__ for table in tables)
 
     def _filter_exact_match_uuids(self, query, uuids):
         column = self.config.column_for_searching('uuid')

--- a/xivo_dao/resources/user/search.py
+++ b/xivo_dao/resources/user/search.py
@@ -62,6 +62,9 @@ config = SearchConfig(
 
 class UserSearchSystem(SearchSystem):
     def search_from_query(self, query, parameters):
+        line_presence_view = parameters.get('view') == 'line_presence'
+        searching = bool(parameters.get('search') or parameters.get('exten'))
+
         if 'uuid' in parameters and isinstance(parameters['uuid'], str):
             uuids = parameters.pop('uuid').split(',')
             query = self._filter_exact_match_uuids(query, uuids)
@@ -76,7 +79,10 @@ class UserSearchSystem(SearchSystem):
             extens = parameters.pop('mobile_phone_number').split(',')
             query = self._filter_exact_match_mobile_phone_numbers(query, extens)
 
-        query = self._search_on_extension(query)
+        if not line_presence_view or searching:
+            query = self._search_on_extension(query)
+            if line_presence_view:
+                query = query.distinct()
         return super().search_from_query(query, parameters)
 
     def _filter_exact_match_uuids(self, query, uuids):

--- a/xivo_dao/resources/user/search.py
+++ b/xivo_dao/resources/user/search.py
@@ -63,6 +63,14 @@ config = SearchConfig(
 
 
 class UserSearchSystem(SearchSystem):
+    def search_from_query_collated(self, query, parameters):
+        # `search_from_query_collated` pops `order` off `parameters` before
+        # calling `search_from_query`, so the line_presence check there never
+        # sees it for this path. Run it here first, on the untouched params.
+        if parameters.get('view') == 'line_presence':
+            self._reject_unsupported_line_presence_params(parameters)
+        return super().search_from_query_collated(query, parameters)
+
     def search_from_query(self, query, parameters):
         line_presence_view = parameters.get('view') == 'line_presence'
         searching = bool(parameters.get('search') or parameters.get('exten'))

--- a/xivo_dao/resources/user/tests/test_dao.py
+++ b/xivo_dao/resources/user/tests/test_dao.py
@@ -833,6 +833,18 @@ class TestLinePresenceView(TestSearch):
             order='exten',
         )
 
+    def test_given_order_by_context_with_line_presence_collated_view_then_raises_error(
+        self,
+    ):
+        # search_collated() pops `order` before calling search_from_query,
+        # so this must be checked independently of the plain search() path
+        self.assert_search_collated_raises_exception(
+            InputError,
+            "Input Error - parameter 'order': 'context' is not valid",
+            view='line_presence',
+            order='context',
+        )
+
     def test_given_fullname_filter_with_line_presence_view_then_still_works(self):
         user = self.add_user(firstname='alice', lastname='wonderland')
 

--- a/xivo_dao/resources/user/tests/test_dao.py
+++ b/xivo_dao/resources/user/tests/test_dao.py
@@ -702,6 +702,83 @@ class TestLinePresenceView(TestSearch):
 
         self.assert_search_returns_result(expected, view='line_presence')
 
+    def test_given_user_with_multiple_lines_then_all_non_commented_lines_are_returned(
+        self,
+    ):
+        sip_1 = self.add_endpoint_sip()
+        sip_2 = self.add_endpoint_sip()
+        user_line = self.add_user_line_with_exten(
+            firstname='bob', endpoint_sip_uuid=sip_1.uuid
+        )
+        second_line = self.add_line(commented=0, endpoint_sip_uuid=sip_2.uuid)
+        self.add_user_line(
+            user_id=user_line.user.id, line_id=second_line.id, main_line=False
+        )
+
+        expected_lines = sorted(
+            [
+                {
+                    'id': user_line.line_id,
+                    'name': user_line.line.name,
+                    'protocol': 'sip',
+                },
+                {
+                    'id': second_line.id,
+                    'name': second_line.name,
+                    'protocol': 'sip',
+                },
+            ],
+            key=lambda line: line['id'],
+        )
+
+        expected = SearchResult(
+            1,
+            [
+                UserLinePresence(
+                    uuid=user_line.user.uuid,
+                    tenant_uuid=user_line.user.tenant_uuid,
+                    dnd_enabled=False,
+                    lines=expected_lines,
+                )
+            ],
+        )
+
+        self.assert_search_returns_result(expected, view='line_presence')
+
+    def test_given_exten_filter_with_line_presence_view_then_returns_one_result(self):
+        sip = self.add_endpoint_sip()
+        user_line = self.add_user_line_with_exten(
+            firstname='bob', endpoint_sip_uuid=sip.uuid
+        )
+        second_extension = self.add_extension()
+        self.add_line_extension(
+            line_id=user_line.line_id,
+            extension_id=second_extension.id,
+            main_extension=False,
+        )
+
+        expected = SearchResult(
+            1,
+            [
+                UserLinePresence(
+                    uuid=user_line.user.uuid,
+                    tenant_uuid=user_line.user.tenant_uuid,
+                    dnd_enabled=False,
+                    lines=[
+                        {
+                            'id': user_line.line_id,
+                            'name': user_line.line.name,
+                            'protocol': 'sip',
+                        }
+                    ],
+                )
+            ],
+        )
+
+        self.assert_search_returns_result(
+            expected, view='line_presence', exten=user_line.extension.exten
+        )
+
 
 class TestSearchGivenMultipleUsers(TestSearch):
     def setUp(self):

--- a/xivo_dao/resources/user/tests/test_dao.py
+++ b/xivo_dao/resources/user/tests/test_dao.py
@@ -32,7 +32,7 @@ from xivo_dao.alchemy.userfeatures import UserFeatures as User
 from xivo_dao.helpers.exception import InputError, NotFoundError
 from xivo_dao.resources.func_key.tests.test_helpers import FuncKeyHelper
 from xivo_dao.resources.user import dao as user_dao
-from xivo_dao.resources.user.model import UserDirectory, UserSummary
+from xivo_dao.resources.user.model import UserDirectory, UserLinePresence, UserSummary
 from xivo_dao.resources.utils.search import SearchResult
 from xivo_dao.tests.test_dao import DAOTestCase
 
@@ -586,6 +586,121 @@ class TestSimpleSearch(TestSearch):
         )
 
         self.assert_search_returns_result(expected, view='directory')
+
+
+class TestLinePresenceView(TestSearch):
+    def test_given_user_without_line_then_returns_empty_lines(self):
+        user = self.add_user(firstname='alice')
+
+        expected = SearchResult(
+            1,
+            [
+                UserLinePresence(
+                    uuid=user.uuid,
+                    tenant_uuid=user.tenant_uuid,
+                    dnd_enabled=False,
+                    lines=[],
+                )
+            ],
+        )
+
+        self.assert_search_returns_result(expected, view='line_presence')
+
+    def test_given_user_with_dnd_enabled_then_dnd_enabled_is_true(self):
+        user = self.add_user(firstname='alice', enablednd=1)
+
+        expected = SearchResult(
+            1,
+            [
+                UserLinePresence(
+                    uuid=user.uuid,
+                    tenant_uuid=user.tenant_uuid,
+                    dnd_enabled=True,
+                    lines=[],
+                )
+            ],
+        )
+
+        self.assert_search_returns_result(expected, view='line_presence')
+
+    def test_given_main_line_with_multiple_extensions_then_returns_one_result(self):
+        sip = self.add_endpoint_sip()
+        user_line = self.add_user_line_with_exten(
+            firstname='bob', endpoint_sip_uuid=sip.uuid
+        )
+        second_extension = self.add_extension()
+        self.add_line_extension(
+            line_id=user_line.line_id,
+            extension_id=second_extension.id,
+            main_extension=False,
+        )
+
+        expected = SearchResult(
+            1,
+            [
+                UserLinePresence(
+                    uuid=user_line.user.uuid,
+                    tenant_uuid=user_line.user.tenant_uuid,
+                    dnd_enabled=False,
+                    lines=[
+                        {
+                            'id': user_line.line_id,
+                            'name': user_line.line.name,
+                            'protocol': 'sip',
+                        }
+                    ],
+                )
+            ],
+        )
+
+        self.assert_search_returns_result(expected, view='line_presence')
+
+    def test_collated_search_orders_by_requested_field(self):
+        user_c = self.add_user(firstname='charlie', lastname='aaa')
+        user_a = self.add_user(firstname='alice', lastname='bbb')
+        user_b = self.add_user(firstname='bob', lastname='ccc')
+
+        result = user_dao.search_collated(
+            view='line_presence',
+            order='firstname',
+            direction='asc',
+            tenant_uuids=[self.default_tenant.uuid],
+        )
+
+        assert_that(
+            [item.uuid for item in result.items],
+            equal_to([user_a.uuid, user_b.uuid, user_c.uuid]),
+        )
+
+    def test_given_commented_line_then_excluded_from_lines(self):
+        sip = self.add_endpoint_sip()
+        user_line = self.add_user_line_with_exten(
+            firstname='bob', endpoint_sip_uuid=sip.uuid
+        )
+        commented_line = self.add_line(commented=1)
+        self.add_user_line(
+            user_id=user_line.user.id, line_id=commented_line.id, main_line=False
+        )
+
+        expected = SearchResult(
+            1,
+            [
+                UserLinePresence(
+                    uuid=user_line.user.uuid,
+                    tenant_uuid=user_line.user.tenant_uuid,
+                    dnd_enabled=False,
+                    lines=[
+                        {
+                            'id': user_line.line_id,
+                            'name': user_line.line.name,
+                            'protocol': 'sip',
+                        }
+                    ],
+                )
+            ],
+        )
+
+        self.assert_search_returns_result(expected, view='line_presence')
 
 
 class TestSearchGivenMultipleUsers(TestSearch):

--- a/xivo_dao/resources/user/tests/test_dao.py
+++ b/xivo_dao/resources/user/tests/test_dao.py
@@ -779,6 +779,93 @@ class TestLinePresenceView(TestSearch):
             expected, view='line_presence', exten=user_line.extension.exten
         )
 
+    def test_given_context_filter_with_line_presence_view_then_raises_error(self):
+        self.assert_search_raises_exception(
+            InputError,
+            "Input Error - parameter 'context': 'default' is not valid",
+            view='line_presence',
+            context='default',
+        )
+
+    def test_given_extension_filter_with_line_presence_view_then_raises_error(self):
+        self.assert_search_raises_exception(
+            InputError,
+            "Input Error - parameter 'extension': '1000' is not valid",
+            view='line_presence',
+            extension='1000',
+        )
+
+    def test_given_provisioning_code_filter_with_line_presence_view_then_raises_error(
+        self,
+    ):
+        self.assert_search_raises_exception(
+            InputError,
+            "Input Error - parameter 'provisioning_code': '123456' is not valid",
+            view='line_presence',
+            provisioning_code='123456',
+        )
+
+    def test_given_voicemail_number_filter_with_line_presence_view_then_raises_error(
+        self,
+    ):
+        self.assert_search_raises_exception(
+            InputError,
+            "Input Error - parameter 'voicemail_number': '1000' is not valid",
+            view='line_presence',
+            voicemail_number='1000',
+        )
+
+    def test_given_order_by_context_with_line_presence_view_then_raises_error(self):
+        self.assert_search_raises_exception(
+            InputError,
+            "Input Error - parameter 'order': 'context' is not valid",
+            view='line_presence',
+            order='context',
+        )
+
+    def test_given_order_by_exten_with_line_presence_view_then_raises_error(self):
+        # unlike an `exten` exact-match filter, sorting by `exten` does not
+        # force the join itself, so it needs the same rejection
+        self.assert_search_raises_exception(
+            InputError,
+            "Input Error - parameter 'order': 'exten' is not valid",
+            view='line_presence',
+            order='exten',
+        )
+
+    def test_given_fullname_filter_with_line_presence_view_then_still_works(self):
+        user = self.add_user(firstname='alice', lastname='wonderland')
+
+        expected = SearchResult(
+            1,
+            [
+                UserLinePresence(
+                    uuid=user.uuid,
+                    tenant_uuid=user.tenant_uuid,
+                    dnd_enabled=False,
+                    lines=[],
+                )
+            ],
+        )
+
+        # `fullname` is a composite expression (firstname + lastname), not a
+        # plain Column, and must not crash the join-requirement check
+        self.assert_search_returns_result(
+            expected, view='line_presence', fullname='alice wonderland'
+        )
+
+    def test_given_context_filter_with_directory_view_then_still_works(self):
+        user_line = self.add_user_line_with_exten(firstname='alice')
+
+        result = user_dao.search(
+            view='directory',
+            context=user_line.extension.context,
+            tenant_uuids=[self.default_tenant.uuid],
+        )
+
+        assert_that(result.total, equal_to(1))
+        assert_that(result.items[0].uuid, equal_to(user_line.user.uuid))
+
 
 class TestSearchGivenMultipleUsers(TestSearch):
     def setUp(self):

--- a/xivo_dao/resources/user/view.py
+++ b/xivo_dao/resources/user/view.py
@@ -1,6 +1,8 @@
 # Copyright 2014-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import aggregate_order_by
 from sqlalchemy.orm import aliased
 from sqlalchemy.sql import and_, case, func
 
@@ -11,7 +13,7 @@ from xivo_dao.alchemy.user_line import UserLine
 from xivo_dao.alchemy.userfeatures import UserFeatures as User
 from xivo_dao.alchemy.voicemail import Voicemail
 from xivo_dao.helpers import errors
-from xivo_dao.resources.user.model import UserDirectory, UserSummary
+from xivo_dao.resources.user.model import UserDirectory, UserLinePresence, UserSummary
 from xivo_dao.resources.utils.view import View, ViewSelector
 
 
@@ -126,6 +128,48 @@ class SummaryView(View):
         )
 
 
+class LinePresenceView(View):
+    def query(self, session):
+        line_obj = func.json_build_object(
+            'id',
+            Line.id,
+            'name',
+            Line.name,
+            'protocol',
+            Line.protocol,
+        )
+        lines = (
+            select(func.json_agg(aggregate_order_by(line_obj, Line.id)))
+            .select_from(UserLine)
+            .join(Line, Line.id == UserLine.line_id)
+            .where(UserLine.user_id == User.id)
+            .where(Line.commented == 0)
+            .correlate(User)
+            .scalar_subquery()
+            .label('lines')
+        )
+        return (
+            session.query(
+                User.uuid.label('uuid'),
+                User.tenant_uuid.label('tenant_uuid'),
+                User.dnd_enabled.label('dnd_enabled'),
+                lines,
+                User.firstname.label('firstname'),
+                User.lastname.label('lastname'),
+            )
+            .select_from(User)
+            .group_by(User.id)
+        )
+
+    def convert(self, row):
+        return UserLinePresence(
+            uuid=row.uuid,
+            tenant_uuid=row.tenant_uuid,
+            dnd_enabled=row.dnd_enabled,
+            lines=row.lines or [],
+        )
+
+
 class UserViewSelector(ViewSelector):
     def select(self, name=None, default_query=None):
         if not name:
@@ -139,5 +183,8 @@ class UserViewSelector(ViewSelector):
 
 
 user_view = UserViewSelector(
-    default=DefaultView(), directory=DirectoryView(), summary=SummaryView()
+    default=DefaultView(),
+    directory=DirectoryView(),
+    summary=SummaryView(),
+    line_presence=LinePresenceView(),
 )

--- a/xivo_dao/resources/user/view.py
+++ b/xivo_dao/resources/user/view.py
@@ -130,7 +130,7 @@ class SummaryView(View):
 
 class LinePresenceView(View):
     def query(self, session):
-        line_obj = func.json_build_object(
+        line_obj = func.jsonb_build_object(
             'id',
             Line.id,
             'name',
@@ -139,26 +139,27 @@ class LinePresenceView(View):
             Line.protocol,
         )
         lines = (
-            select(func.json_agg(aggregate_order_by(line_obj, Line.id)))
+            select(
+                UserLine.user_id.label('user_id'),
+                func.jsonb_agg(aggregate_order_by(line_obj, Line.id)).label('lines'),
+            )
             .select_from(UserLine)
             .join(Line, Line.id == UserLine.line_id)
-            .where(UserLine.user_id == User.id)
             .where(Line.commented == 0)
-            .correlate(User)
-            .scalar_subquery()
-            .label('lines')
+            .group_by(UserLine.user_id)
+            .subquery()
         )
         return (
             session.query(
                 User.uuid.label('uuid'),
                 User.tenant_uuid.label('tenant_uuid'),
                 User.dnd_enabled.label('dnd_enabled'),
-                lines,
+                lines.c.lines.label('lines'),
                 User.firstname.label('firstname'),
                 User.lastname.label('lastname'),
             )
             .select_from(User)
-            .group_by(User.id)
+            .outerjoin(lines, lines.c.user_id == User.id)
         )
 
     def convert(self, row):


### PR DESCRIPTION
## Summary

Adds a new `line_presence` user view to the user resource, exposing per-user presence data:

- `uuid`, `tenant_uuid`, `dnd_enabled`, and the user's `lines`
- one presence row per user
- `lines` lists the user's **non-commented** lines (`id`, `name`, `protocol`) in a deterministic order, and is an **empty list** when the user has none
- results are sortable by user fields (e.g. `firstname`, `lastname`) through the collated search path

## Implementation notes

- `lines` is built with a correlated `json_agg` scalar subquery so the aggregation stays isolated from the joins the search system adds (`_search_on_extension`), avoiding the `aliased()` gymnastics `SummaryView` needs.
- The outer query groups by the user primary key, so the row/count inflation from the search system's `LineExtension` outerjoin (one row per extension) collapses to a single presence row per user.
- `firstname`/`lastname` are selected as sort keys (consumed by the collated search) but are **not** part of the `UserLinePresence` output.

## Tests

`TestLinePresenceView` covers: empty lines, DND, multi-extension dedup, commented-line exclusion, and collated ordering by a requested field. Full user-resource suite (81 tests) passes; pre-commit clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New PostgreSQL aggregation and search-path branching affect user listing queries; incorrect join handling could skew results, though guards and tests target that.
> 
> **Overview**
> Adds a **`line_presence`** user search view that returns one row per user with `uuid`, `tenant_uuid`, `dnd_enabled`, and a **`lines`** array (`id`, `name`, `protocol`) built from non-commented lines via a grouped `jsonb_agg` subquery.
> 
> **`UserSearchSystem`** is extended so this view skips the usual extension join unless `search` or **`exten`** filtering needs it (with **`distinct`** when joined), and rejects filters/sort on join-dependent fields (`context`, `extension`, `provisioning_code`, `voicemail_number`, ordering by `exten`/`context`) including on the collated search path. Other views (e.g. `directory`) are unchanged.
> 
> **`TestLinePresenceView`** covers empty lines, DND, multi-line/multi-extension behavior, collated ordering, and invalid-parameter errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bcbdbf3410eb3aac2f0536a164221c7c13a330df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->