### PR TITLE
fix(asterisk-options): make native option order deterministic

### DIFF
--- a/xivo_dao/helpers/asterisk.py
+++ b/xivo_dao/helpers/asterisk.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from collections.abc import Iterable
@@ -106,7 +106,11 @@ class AsteriskOptionsMixin:
 
     def native_option_names(self, exclude=None):
         exclude = set(exclude or []).union(self.EXCLUDE_OPTIONS)
-        return {column.name for column in self.__table__.columns} - exclude
+        return [
+            column.name
+            for column in self.__table__.columns
+            if column.name not in exclude
+        ]
 
     def option_defaults(self):
         defaults = {}


### PR DESCRIPTION
## Problem

`AsteriskOptionsMixin.native_option_names()` returns a **set**, and `native_options()` iterates it to build the ordered `options` list. Set-of-strings iteration order depends on `PYTHONHASHSEED`, which is randomized per process.

Within a single process the order is stable, so this was never noticed. But across processes — or simply after a restart — the same endpoint's `options` come back in a different order. This surfaced while load-balancing requests across multiple service processes: a resource created on one process and read back from another returned its options in a different order.

## Fix

Return a **list preserving column-definition order** instead of a set. SQLAlchemy's `__table__.columns` order is deterministic and identical across processes.

```python
def native_option_names(self, exclude=None):
    exclude = set(exclude or []).union(self.EXCLUDE_OPTIONS)
    return [
        column.name
        for column in self.__table__.columns
        if column.name not in exclude
    ]
```

The three call sites are all safe with a list: `native_options()` (the one that matters — now deterministic), the `options` setter's `column in option_names` membership check, and `reset_native_options()` (order irrelevant). `exclude` stays a set for O(1) lookups.

## Impact

Affects all `AsteriskOptionsMixin` subclasses. API `options` arrays and generated Asterisk config option order become stable instead of reshuffling per process/restart — functionally inert for Asterisk, strictly better for determinism and diffability.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small behavioral fix for ordering only; no auth, data, or Asterisk semantics change, with list membership checks still acceptable for small column sets.
> 
> **Overview**
> **`AsteriskOptionsMixin.native_option_names()`** now returns a **list** of column names in SQLAlchemy **`__table__.columns`** order instead of a **set**, so **`native_options()`** / API **`options`** arrays no longer shuffle across processes or restarts (previously tied to **`PYTHONHASHSEED`**).
> 
> Call sites that iterate names or use **`column in option_names`** keep working; **`exclude`** remains a set for fast membership checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd241001496aaef788b89aafcf9937994b2412ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->