### PR TITLE
ITEM-424-fix-agent-status-for-logoff-queues

### DIFF
--- a/xivo_dao/agent_status_dao.py
+++ b/xivo_dao/agent_status_dao.py
@@ -1,4 +1,4 @@
-# Copyright 2007-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2007-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
@@ -105,12 +105,25 @@ def get_agent_login_status_by_id_for_logoff(
     )
     if not status:
         return None
-    queues = (
-        session.query(QueueFeatures)
+    memberships = (
+        session.query(QueueFeatures, AgentMembershipStatus.penalty)
         .join(AgentMembershipStatus, AgentMembershipStatus.queue_id == QueueFeatures.id)
         .filter(AgentMembershipStatus.agent_id == agent_id)
         .all()
     )
+    queues = [
+        _Queue(
+            id=queue.id,
+            name=queue.name,
+            display_name=queue.displayname,
+            penalty=penalty,
+            logged=True,
+            paused=status.paused,
+            paused_reason=status.paused_reason,
+            login_at=status.login_at,
+        )
+        for queue, penalty in memberships
+    ]
     agent = status.agent
     user_ids = [user.id for user in agent.users] if agent else []
     return _AgentStatus(

--- a/xivo_dao/tests/test_agent_status_dao.py
+++ b/xivo_dao/tests/test_agent_status_dao.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from collections import namedtuple
@@ -756,12 +756,31 @@ class TestAgentStatusDao(DAOTestCase):
 
     def test_get_agent_login_status_by_id_for_logoff(self):
         agent = self.add_agent()
-        self._insert_agent_login_status(agent.id, agent.number)
+        queue = self.add_queuefeatures(name='queue1')
+        login_status = self._insert_agent_login_status(agent.id, agent.number)
+        self._insert_agent_membership(agent.id, queue.id, queue.name, queue_penalty=42)
 
         agent_login_status = agent_status_dao.get_agent_login_status_by_id_for_logoff(
             agent.id
         )
-        assert_that(agent_login_status, has_properties(agent_id=agent.id))
+        assert_that(
+            agent_login_status,
+            has_properties(
+                agent_id=agent.id,
+                queues=contains_exactly(
+                    has_properties(
+                        id=queue.id,
+                        name=queue.name,
+                        display_name=queue.displayname,
+                        penalty=42,
+                        logged=True,
+                        paused=login_status.paused,
+                        paused_reason=login_status.paused_reason,
+                        login_at=login_status.login_at,
+                    ),
+                ),
+            ),
+        )
 
         agent_status_dao.log_off_agent(agent.id)
 


### PR DESCRIPTION
Why: get_agent_login_status_by_id_for_logoff returned raw QueueFeatures
rows in queues, which lack the logged attribute that consumers of
_AgentStatus.queues rely on. Handling agent_deleted in wazo-agentd
crashed with AttributeError before any cleanup, leaving a stale
agent_login_status row and the agent still active in asterisk queues.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the agent logoff/cleanup path used when agents are removed; incorrect queue data could leave stale Asterisk membership, but the change is a narrow contract fix with test coverage.
> 
> **Overview**
> Fixes agent logoff cleanup when an agent is deleted: **`get_agent_login_status_by_id_for_logoff`** now builds **`_Queue`** named tuples for **`queues`** instead of raw **`QueueFeatures`** rows.
> 
> The query joins **`AgentMembershipStatus`** to include **penalty**, and each queue entry gets **`logged=True`** plus pause/login fields copied from the agent login status. That matches what **`_AgentStatus.queues`** consumers (e.g. wazo-agentd on **`agent_deleted`**) expect, avoiding **`AttributeError`** on missing **`logged`** and incomplete cleanup in Asterisk.
> 
> The logoff DAO test now seeds queue membership and asserts the full queue shape (penalty, display name, paused state, **`login_at`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 066dae7a6a787c8f401de61e7c4bd2865aafa69c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->