### PR TITLE
ITEM-447-dynamic-thread-pool

### DIFF
--- a/xivo_dao/helpers/db_manager.py
+++ b/xivo_dao/helpers/db_manager.py
@@ -13,6 +13,7 @@ DEFAULT_DB_URI = (
     'postgresql://asterisk:proformatique@localhost/asterisk?application_name=xivo-dao'
 )
 DEFAULT_POOL_SIZE = 16
+DB_POOL_SPARE_CONN = 10
 
 logger = logging.getLogger(__name__)
 Session = scoped_session(sessionmaker())
@@ -108,7 +109,11 @@ def init_db_from_config(config=None):
     # Dynamic HTTP thread pool: retain connections only for the always-alive
     # threads. Bursts borrow overflow connections, which SQLAlchemy closes on
     # return — mirroring the thread pool shrinking back after the burst.
-    init_db(url, pool_size=min_threads, max_overflow=max_threads - min_threads)
+    init_db(
+        url,
+        pool_size=min_threads,
+        max_overflow=max_threads - min_threads + DB_POOL_SPARE_CONN,
+    )
 
 
 def default_config():

--- a/xivo_dao/helpers/db_manager.py
+++ b/xivo_dao/helpers/db_manager.py
@@ -1,4 +1,4 @@
-# Copyright 2012-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2012-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -86,8 +86,10 @@ def daosession(func):
     return wrapped
 
 
-def init_db(db_uri, pool_size=DEFAULT_POOL_SIZE):
-    engine = create_engine(db_uri, pool_size=pool_size, pool_pre_ping=True)
+def init_db(db_uri, pool_size=DEFAULT_POOL_SIZE, max_overflow=10):
+    engine = create_engine(
+        db_uri, pool_size=pool_size, max_overflow=max_overflow, pool_pre_ping=True
+    )
     Session.configure(bind=engine)
     Base.metadata.bind = engine
 
@@ -96,10 +98,17 @@ def init_db_from_config(config=None):
     config = config or default_config()
     url = config.get('db_uri', DEFAULT_DB_URI)
     try:
-        pool_size = config['rest_api']['max_threads']
+        min_threads = config['rest_api']['min_threads']
+        max_threads = config['rest_api']['max_threads']
     except KeyError:
-        pool_size = DEFAULT_POOL_SIZE
-    init_db(url, pool_size=pool_size)
+        # Consumers without a REST API (agid, purge-db, ...)
+        init_db(url)
+        return
+
+    # Dynamic HTTP thread pool: retain connections only for the always-alive
+    # threads. Bursts borrow overflow connections, which SQLAlchemy closes on
+    # return — mirroring the thread pool shrinking back after the burst.
+    init_db(url, pool_size=min_threads, max_overflow=max_threads - min_threads)
 
 
 def default_config():


### PR DESCRIPTION
Why: pool_size was set from rest_api.max_threads and SQLAlchemy
retains pool_size connections once opened, so a dynamic HTTP thread
pool would keep its peak connection count forever after a burst.
Retain only min_threads connections; bursts borrow overflow
connections that are closed when returned, matching the thread pool
shrinking back.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes connection pool sizing for all REST API consumers; misaligned min/max thread config or PostgreSQL max_connections could cause pool exhaustion under burst load.
> 
> **Overview**
> Aligns the SQLAlchemy connection pool with a **dynamic HTTP thread pool** so peak load no longer leaves a permanently enlarged pool of open DB connections.
> 
> **`init_db_from_config`** now sizes **`pool_size`** from **`rest_api.min_threads`** (always-on workers) instead of **`max_threads`**, and sets **`max_overflow`** to **`max_threads - min_threads + DB_POOL_SPARE_CONN`** (10 spare) so burst traffic can borrow extra connections that are **closed when returned**, matching threads shrinking after a spike. **`init_db`** gains an explicit **`max_overflow`** argument passed through to **`create_engine`**. Processes **without** **`rest_api`** config still call **`init_db(url)`** with defaults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6155130c542ad780743c50b7d0093ca643f91bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->